### PR TITLE
feat: maintainer feedback round — AGENTS.md drop-in, tracker seam, SDLC.md, per-skill overrides

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -24,9 +24,19 @@ All skills read a single per-repo config file, `.ai/agentic.config.json`, writte
 
 CI greps `skills/**` for tokens that would betray monorepo leakage: the `om-` prefix, Open Mercato references, a hard-coded base branch name, a hard-coded package manager, and upstream-only file conventions. The gate is scoped to `skills/**`; README, LICENSE, and this file may reference the upstream project.
 
+One token was initially banned and then deliberately unbanned: `AGENTS.md`. The ban guarded against leaked references to the upstream monorepo's root guidelines file, but AGENTS.md is an open standard and reading it is exactly how the skills pick up project specifics — including when installed into Open Mercato itself, which makes the collection a drop-in there with zero upstream changes. The gate now bans the upstream-specific concept ("Task Router") instead of the filename.
+
+## Project fit: AGENTS.md, SDLC.md, overrides
+
+Project-specific knowledge lives in three places, none of them inside the installed skills. Machine-readable settings go in `.ai/agentic.config.json`. Prose specifics (coding standards, architecture, conventions) go in the repo's own `AGENTS.md`/`CLAUDE.md`, which every skill reads before working; `setup-agent-pipeline` scaffolds a starter when none exists. Per-skill behavior changes go in `.ai/agentic-overrides/<skill-name>.md`, applied on top of the installed skill with local rules winning — the portable equivalent of skill inheritance, chosen over an `@`-include mechanism because include semantics differ across coding agents while "read this file and honor it" works in all of them. `setup-agent-pipeline` also generates `SDLC.md`, a human-readable description of the ticket flow the skills automate (stages, label state machine, QA gate, claim protocol), so the process is documented for people, not only encoded in skills.
+
+## Tracker abstraction
+
+Issue/PR state management defaults to GitHub via the `gh` CLI, called inline by the skills. The config's `tracker` field is the extension seam: a future provider (for example Linear) lands as ONE dedicated skill implementing the full set of state operations (list/read/create/close, comment, label, assign, review, merge, check status), selected by that field. One skill per provider rather than many micro-skills, to keep agent context small. v1 ships no provider other than GitHub; extracting the inline `gh` calls into a `tracker-github` skill is deliberately deferred until a second provider makes the indirection pay for itself.
+
 ## Deferred
 
 - A bespoke `npx open-mercato-skills` installer CLI. skills.sh covers installation in v1.
-- Issue trackers other than GitHub. `setup-agent-pipeline` is GitHub-only in v1.
+- Tracker providers other than GitHub (`tracker-linear` and friends), and the extraction of inline `gh` calls into a `tracker-github` provider skill. The seam (`tracker` config field + one-skill-per-provider contract) ships in v1; the providers do not.
 - Skills beyond the PR pipeline (module scaffolding, design-system review, integration testing). Those are product-specific upstream and were deliberately not extracted.
 - Automated sync from the upstream monorepo. Curation is manual.

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ These skills wrote and shipped a real product. Inside the [Open Mercato](https:/
 ## 30-second quickstart
 
 ```bash
-npx skills add open-mercato/skills
+npx skills add open-mercato/skills --skill '*'
 ```
 
-This installs the skills for 22+ coding agents (Claude Code, Cursor, Codex, and others) via [skills.sh](https://skills.sh).
+Install all fifteen — the pipeline composes, and every skill is small until invoked. Drop `--skill '*'` to cherry-pick interactively. Skills install for 22+ coding agents (Claude Code, Cursor, Codex, and others) via [skills.sh](https://skills.sh).
 
 Then, once per repository:
 
@@ -19,7 +19,7 @@ Then, once per repository:
 /setup-agent-pipeline
 ```
 
-It inspects your repo (default branch, validation scripts, GitHub labels), asks a few questions, and writes `.ai/agentic.config.json`. Every other skill reads that file.
+It inspects your repo (default branch, validation scripts, GitHub labels), asks a few questions, writes `.ai/agentic.config.json`, and generates `SDLC.md` — your team's ticket-flow doc. Every other skill reads the config.
 
 Then ship something:
 
@@ -58,7 +58,7 @@ flowchart LR
 
 | Skill | What it does |
 |---|---|
-| `setup-agent-pipeline` | One-per-repo configurator. Inspects the repository, asks a few questions, writes `.ai/agentic.config.json`. |
+| `setup-agent-pipeline` | One-per-repo configurator. Inspects the repository, asks a few questions, writes `.ai/agentic.config.json`, generates `SDLC.md` and an `AGENTS.md` starter when missing. |
 | `auto-create-pr` | Takes a free-form task brief end-to-end: execution plan, isolated worktree, phase-by-phase commits, validation gate, labeled PR. Resumable. |
 | `auto-continue-pr` | Resumes an in-progress PR from the first unchecked step in its tracking plan. |
 | `auto-review-pr` | Reviews a PR by number in an isolated worktree, approves or requests changes, manages labels. On changes-requested, its autofix loop iterates fixes and re-review until merge-ready. |
@@ -89,6 +89,7 @@ Nothing here assumes JavaScript, or any particular product. The base branch, the
 {
   "version": 1,
   "baseBranch": "auto",
+  "tracker": "github",
   "validation": {
     "commands": ["pnpm typecheck", "pnpm test", "pnpm build"]
   },
@@ -110,6 +111,16 @@ Nothing here assumes JavaScript, or any particular product. The base branch, the
 ```
 
 A Rust repo puts `cargo test` and `cargo clippy` in `validation.commands`; a Go repo puts `go test ./...`. Skills run whatever you configure and treat any non-zero exit as a gate failure. A skill invoked in a repo without the config stops and points you at `setup-agent-pipeline`.
+
+GitHub is the default tracker; the `tracker` field is the seam for others (Linear and friends land as one provider skill each — see the tracker section in `setup-agent-pipeline`).
+
+## Make it yours
+
+Three layers of project fit, no forking:
+
+- **Agent instructions** — skills read your `AGENTS.md` / `CLAUDE.md` before working, so project conventions apply from the first run. No such file? `setup-agent-pipeline` offers a starter.
+- **`SDLC.md`** — the generated process doc: pipeline stages, label state machine, QA gate, claim protocol. Humans read it; new team members stop asking how the flow works.
+- **Per-skill overrides** — drop `.ai/agentic-overrides/<skill-name>.md` into your repo and that skill applies it on top of its own instructions; local rules win. Extra review rules, a different PR template, an added gate step — without touching the installed skill.
 
 ## Labels and the QA gate
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -41,7 +41,7 @@ patterns=(
   '(^|[^[:alnum:]])yarn '
   '\.ai/specs'
   'findWithDecryption'
-  'AGENTS\.md'
+  'Task Router'
   'BACKWARD_COMPATIBILITY'
 )
 

--- a/skills/apply-fix/SKILL.md
+++ b/skills/apply-fix/SKILL.md
@@ -16,7 +16,7 @@ Your job: implement the proposed change, prove it works, and stop. The next step
 
 ## Load pipeline config
 
-Load `.ai/agentic.config.json` using the standard snippet from the `setup-agent-pipeline` skill. If the file is missing, stop and tell the user to run `setup-agent-pipeline` first. This step uses `labels.enabled` (for the claim label) and `validation.commands` (for the gate below):
+Load `.ai/agentic.config.json` using the standard snippet from the `setup-agent-pipeline` skill. If the file is missing, stop and tell the user to run `setup-agent-pipeline` first. Right after loading the config, check for `.ai/agentic-overrides/apply-fix.md`; when present, apply it on top of these instructions — local rules win, but an override can never relax this skill's safety rules. Also consult the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics. This step uses `labels.enabled` (for the claim label) and `validation.commands` (for the gate below):
 
 ```bash
 CONFIG=.ai/agentic.config.json

--- a/skills/approve-merge-pr/SKILL.md
+++ b/skills/approve-merge-pr/SKILL.md
@@ -21,7 +21,7 @@ Given a single PR number, submit an approving review and then squash-merge it. O
    LABELS_ENABLED=$(jq -r '.labels.enabled // false' "$CONFIG")
    QA_GATE=$(jq -r '.qaGate // false' "$CONFIG")
    ```
-   All label names below come from the config's label taxonomy.
+   All label names below come from the config's label taxonomy. Right after loading the config, check for `.ai/agentic-overrides/approve-merge-pr.md`; when present, apply it on top of these instructions — local rules win, but an override can never relax this skill's safety rules. Also consult the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics.
 
 1. **Resolve the PR and sanity-check it.** Run:
    ```bash

--- a/skills/auto-continue-pr/SKILL.md
+++ b/skills/auto-continue-pr/SKILL.md
@@ -17,7 +17,7 @@ Resume an `auto-create-pr` run that did not finish in one go. Given a PR number,
 
 ### 0. Load pipeline config and claim the PR
 
-Load `.ai/agentic.config.json` using the standard snippet from the `setup-agent-pipeline` skill. If the file is missing, stop and tell the user to run `setup-agent-pipeline` first. This resolves `BASE_BRANCH`, `RUNS_DIR`, `LABELS_ENABLED`, `QA_GATE`, and the `validation.commands` gate used below.
+Load `.ai/agentic.config.json` using the standard snippet from the `setup-agent-pipeline` skill. If the file is missing, stop and tell the user to run `setup-agent-pipeline` first. This resolves `BASE_BRANCH`, `RUNS_DIR`, `LABELS_ENABLED`, `QA_GATE`, and the `validation.commands` gate used below. Right after loading the config, check for `.ai/agentic-overrides/auto-continue-pr.md`; when present, apply it on top of these instructions — local rules win, but an override can never relax this skill's safety rules. Also consult the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics.
 
 Auto-skills MUST NOT clobber each other. Before doing anything else, decide whether you may claim this PR.
 

--- a/skills/auto-create-pr/SKILL.md
+++ b/skills/auto-create-pr/SKILL.md
@@ -18,7 +18,7 @@ Turn a free-form task brief into a disciplined autonomous run: an execution plan
 
 ### 0. Load pipeline config, pre-flight, and claim
 
-Load `.ai/agentic.config.json` using the standard snippet from the `setup-agent-pipeline` skill. If the file is missing, stop and tell the user to run `setup-agent-pipeline` first. This resolves `BASE_BRANCH`, `RUNS_DIR`, `LABELS_ENABLED`, `QA_GATE`, and the validation commands used below.
+Load `.ai/agentic.config.json` using the standard snippet from the `setup-agent-pipeline` skill. If the file is missing, stop and tell the user to run `setup-agent-pipeline` first. This resolves `BASE_BRANCH`, `RUNS_DIR`, `LABELS_ENABLED`, `QA_GATE`, and the validation commands used below. Right after loading the config, check for `.ai/agentic-overrides/auto-create-pr.md`; when present, apply it on top of these instructions — local rules win, but an override can never relax this skill's safety rules. Also consult the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics.
 
 Before writing anything, confirm no other run owns the slot.
 
@@ -67,7 +67,7 @@ If the user passed one or more `--skill-url` arguments, fetch each URL and extra
 
 Read enough project context to avoid blind work:
 
-- The repository's agent instructions and contributing docs (for example `CLAUDE.md`, `CONTRIBUTING.md`, or equivalents), plus any docs covering the affected area.
+- The repository's agent instructions and contributing docs (`AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, or equivalents), plus any docs covering the affected area.
 - Existing design docs or architecture notes for the same area, when the repo keeps them.
 
 Then reduce the brief to:

--- a/skills/auto-review-pr/SKILL.md
+++ b/skills/auto-review-pr/SKILL.md
@@ -16,7 +16,7 @@ Review a GitHub pull request by number without touching the current worktree. Al
 
 ### 0. Load pipeline config, then claim the PR
 
-Load `.ai/agentic.config.json` using the standard snippet from the `setup-agent-pipeline` skill. If the file is missing, stop and tell the user to run `setup-agent-pipeline` first. This skill uses `LABELS_ENABLED`, `QA_GATE`, and the `validation.commands` gate; the PR's own `baseRefName` is authoritative for diffs and conflict resolution.
+Load `.ai/agentic.config.json` using the standard snippet from the `setup-agent-pipeline` skill. If the file is missing, stop and tell the user to run `setup-agent-pipeline` first. This skill uses `LABELS_ENABLED`, `QA_GATE`, and the `validation.commands` gate; the PR's own `baseRefName` is authoritative for diffs and conflict resolution. Right after loading the config, check for `.ai/agentic-overrides/auto-review-pr.md`; when present, apply it on top of these instructions — local rules win, but an override can never relax this skill's safety rules. Also consult the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics.
 
 Auto-skills MUST NOT clobber each other. Before doing anything else, decide whether you may claim this PR.
 

--- a/skills/check-and-commit/SKILL.md
+++ b/skills/check-and-commit/SKILL.md
@@ -18,7 +18,7 @@ Use this skill when the user wants a branch verified end to end and published on
 
 ## Configuration
 
-Load `.ai/agentic.config.json` using the standard snippet from the `setup-agent-pipeline` skill. If the file is missing, stop and tell the user to run `setup-agent-pipeline` first. The verification gates come from the config:
+Load `.ai/agentic.config.json` using the standard snippet from the `setup-agent-pipeline` skill. If the file is missing, stop and tell the user to run `setup-agent-pipeline` first. Right after loading the config, check for `.ai/agentic-overrides/check-and-commit.md`; when present, apply it on top of these instructions — local rules win, but an override can never relax this skill's safety rules. Also consult the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics. The verification gates come from the config:
 
 ```bash
 jq -r '.validation.commands[]' .ai/agentic.config.json

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -27,7 +27,7 @@ Callers (`auto-review-pr`, `review-prs`, the self-review step of `auto-create-pr
 
 ## Review Workflow
 
-0. **Load config**: Load `.ai/agentic.config.json` using the standard snippet from the `setup-agent-pipeline` skill. If the file is missing, stop and tell the user to run `setup-agent-pipeline` first. This resolves `$BASE_BRANCH` and `validation.commands`. Also read the optional repo-local checklist path:
+0. **Load config**: Load `.ai/agentic.config.json` using the standard snippet from the `setup-agent-pipeline` skill. If the file is missing, stop and tell the user to run `setup-agent-pipeline` first. This resolves `$BASE_BRANCH` and `validation.commands`. Right after loading the config, check for `.ai/agentic-overrides/code-review.md`; when present, apply it on top of these instructions — local rules win, but an override can never relax this skill's safety rules. Also consult the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics. Also read the optional repo-local checklist path:
 
    ```bash
    REVIEW_CHECKLIST=$(jq -r '.reviewChecklist // empty' .ai/agentic.config.json)

--- a/skills/followup-issue-from-pr/SKILL.md
+++ b/skills/followup-issue-from-pr/SKILL.md
@@ -27,7 +27,7 @@ When a plain PR link is pasted, always run the design-doc check (step 2a) in add
    BASE_BRANCH=$(jq -r '.baseBranch // "auto"' "$CONFIG")   # resolve "auto" per the standard snippet
    LABELS_ENABLED=$(jq -r '.labels.enabled // false' "$CONFIG")
    ```
-   Label names come from the config's category taxonomy. When the URL points at a different repo than the current one, still honor `labels.enabled`, but run label existence checks against the target repo (`gh label list --repo <owner>/<repo>`).
+   Label names come from the config's category taxonomy. When the URL points at a different repo than the current one, still honor `labels.enabled`, but run label existence checks against the target repo (`gh label list --repo <owner>/<repo>`). Right after loading the config, check for `.ai/agentic-overrides/followup-issue-from-pr.md`; when present, apply it on top of these instructions — local rules win, but an override can never relax this skill's safety rules. Also consult the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics.
 
 1. **Parse the URL** into `owner`, `repo`, PR `<num>`, and comment id (if present). Note which kind of comment id it is:
    - `issuecomment-<id>` → issue/PR conversation comment.

--- a/skills/merge-buddy/SKILL.md
+++ b/skills/merge-buddy/SKILL.md
@@ -18,7 +18,7 @@ LABELS_ENABLED=$(jq -r '.labels.enabled // false' "$CONFIG")
 QA_GATE=$(jq -r '.qaGate // false' "$CONFIG")
 ```
 
-Every label name below comes from the config's label taxonomy (`labels.pipeline`, `labels.meta`). When `labels.enabled` is `false`, skip all label-based gates, classify from reviews, CI, and mergeability alone, and say so in the report header.
+Every label name below comes from the config's label taxonomy (`labels.pipeline`, `labels.meta`). When `labels.enabled` is `false`, skip all label-based gates, classify from reviews, CI, and mergeability alone, and say so in the report header. Right after loading the config, check for `.ai/agentic-overrides/merge-buddy.md`; when present, apply it on top of these instructions — local rules win, but an override can never relax this skill's safety rules. Also consult the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics.
 
 ### 1. Fetch open PRs
 

--- a/skills/open-pr/SKILL.md
+++ b/skills/open-pr/SKILL.md
@@ -34,7 +34,7 @@ LABELS_ENABLED=$(jq -r '.labels.enabled // false' "$CONFIG")
 QA_GATE=$(jq -r '.qaGate // false' "$CONFIG")
 ```
 
-Every label mutation below goes through the `label_exists` / `apply_label` guards from the same snippet. When `labels.enabled` is `false`, skip every label operation and note that in the closing issue comment.
+Every label mutation below goes through the `label_exists` / `apply_label` guards from the same snippet. When `labels.enabled` is `false`, skip every label operation and note that in the closing issue comment. Right after loading the config, check for `.ai/agentic-overrides/open-pr.md`; when present, apply it on top of these instructions — local rules win, but an override can never relax this skill's safety rules. Also consult the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics.
 
 ## Tools
 

--- a/skills/review-prs/SKILL.md
+++ b/skills/review-prs/SKILL.md
@@ -11,7 +11,7 @@ Use this as a day-start review queue. It finds unreviewed open PRs, shows the qu
 
 ### 0. Load pipeline config
 
-Load `.ai/agentic.config.json` using the standard snippet from the `setup-agent-pipeline` skill. If the file is missing, stop and tell the user to run `setup-agent-pipeline` first. This skill uses `LABELS_ENABLED` for the label-based queue filters below; each individual review delegates to `auto-review-pr`, which loads the rest of the config itself.
+Load `.ai/agentic.config.json` using the standard snippet from the `setup-agent-pipeline` skill. If the file is missing, stop and tell the user to run `setup-agent-pipeline` first. This skill uses `LABELS_ENABLED` for the label-based queue filters below; each individual review delegates to `auto-review-pr`, which loads the rest of the config itself. Right after loading the config, check for `.ai/agentic-overrides/review-prs.md`; when present, apply it on top of these instructions — local rules win, but an override can never relax this skill's safety rules. Also consult the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics.
 
 ### 1. Fetch open PRs
 

--- a/skills/root-cause/SKILL.md
+++ b/skills/root-cause/SKILL.md
@@ -35,7 +35,7 @@ Skim the body and the last few comments. Note explicit reproduction steps and an
 
 ### 2. Read just enough project context
 
-Read the repository's agent instructions and contributing docs (for example `CLAUDE.md`, `CONTRIBUTING.md`, or equivalents) for the affected area. If the repo keeps design docs, architecture notes, or lessons files related to the affected area, skim them.
+Read the repository's agent instructions and contributing docs (`AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, or equivalents) for the affected area. Project context also includes `.ai/agentic-overrides/root-cause.md` when it exists — apply it on top of these instructions, local rules win, but it can never relax this skill's safety rules. If the repo keeps design docs, architecture notes, or lessons files related to the affected area, skim them.
 
 Stop reading project context as soon as you can name the file(s) involved. Do not pre-emptively read the whole codebase.
 

--- a/skills/setup-agent-pipeline/SKILL.md
+++ b/skills/setup-agent-pipeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup-agent-pipeline
-description: One-time configurator for the agent PR pipeline. Inspects the repository (default branch, validation scripts, GitHub labels), asks a few questions, and writes .ai/agentic.config.json — the file every other skill in this collection reads. Run once per repository; re-run when the toolchain or label taxonomy changes.
+description: One-time configurator for the agent PR pipeline. Inspects the repository (default branch, validation scripts, GitHub labels), asks a few questions, writes .ai/agentic.config.json — the file every other skill in this collection reads — and generates SDLC.md (the team's ticket-flow process doc) plus an AGENTS.md starter when the repo has none. Run once per repository; re-run when the toolchain or label taxonomy changes.
 ---
 
 # Setup Agent Pipeline
@@ -19,6 +19,7 @@ Every skill in this collection reads its repository-specific settings from `.ai/
 {
   "version": 1,
   "baseBranch": "auto",
+  "tracker": "github",
   "validation": {
     "commands": ["pnpm typecheck", "pnpm test", "pnpm build"]
   },
@@ -42,6 +43,7 @@ Every skill in this collection reads its repository-specific settings from `.ai/
 Field reference:
 
 - `baseBranch` — the branch PRs target. `"auto"` means: resolve at runtime from the repository's default branch (see the loading snippet below). Set an explicit name only when PRs must target something other than the default branch.
+- `tracker` — the issue/PR tracker provider. v1 ships `"github"` (the `gh` CLI, used inline across the collection). This field is the extension seam for other trackers — see Tracker providers below.
 - `validation.commands` — ordered list of shell commands that constitute the full validation gate. Skills run them in order and treat any non-zero exit as a gate failure. Keep the list complete: typecheck, lint, tests, build — whatever proves the repo is healthy.
 - `labels.enabled` — when `false`, skills skip every label operation and note that in their PR summaries. Use this for repos that do not want the label workflow.
 - `labels.pipeline` — mutually exclusive workflow states. A PR carries at most one.
@@ -53,6 +55,23 @@ Field reference:
 - `paths.runs` — where execution plans of autonomous runs are stored.
 - `paths.analysis` — where generated reports are stored.
 - `reviewChecklist` — optional path to a repo-local review checklist file. When set, the `code-review` skill reads it in addition to its built-in checklist.
+
+## Tracker providers
+
+All issue/PR state management in this collection assumes one provider, selected by the `tracker` config field. v1 ships GitHub only: skills call the `gh` CLI directly, and the operations they rely on form the provider contract — listing and reading issues and PRs, creating and closing issues, commenting, adding and removing labels, assigning, requesting reviews, approving, merging, and reading CI/check status.
+
+A future provider (for example Linear) is added as ONE dedicated skill that implements the same operations end-to-end, plus a `tracker` value that routes state operations to it. One skill per provider — never a scatter of micro-skills per operation — so the extension does not pollute agent context. Until such a provider exists, `tracker` values other than `"github"` are an error: stop and tell the user.
+
+## Project docs: SDLC.md and AGENTS.md
+
+Beyond the config, this skill produces the human-readable half of the pipeline:
+
+- `SDLC.md` (repo root) — the team's ticket flow: pipeline stages, the label state machine, the QA gate, the claim protocol, and which skill drives each stage. Generate it from `references/sdlc-template.md`, filling in the resolved base branch, tracker, label mode, QA gate, and validation commands. When the repo already documents its process, offer to skip or to link instead of overwrite.
+- `AGENTS.md` starter — agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) are where a project records its own specifics: coding standards, architecture notes, conventions. Every skill in this collection reads them before working, so a repo with rich agent docs gets project-aware behavior the moment the skills are installed. When the repo has no such file, offer to generate a starter `AGENTS.md` containing: a one-paragraph project overview (derive from the README or ask), a coding-standards section (seed with conventions detected in the codebase, leave TODO markers where you cannot infer), the validation commands from the config, and pointers to `SDLC.md` and `.ai/agentic.config.json`. When one exists, never touch it.
+
+## Per-skill local overrides
+
+Every skill in this collection checks, right after loading the config, for a repo-local override file at `.ai/agentic-overrides/<skill-name>.md` (for example `.ai/agentic-overrides/auto-review-pr.md`). When present, the skill reads it and applies it on top of its own instructions; where the two conflict, the local override wins. Use it to extend or reshape a skill for one repository without forking the skill itself — extra review rules, a different PR body template, additional gate steps. This skill does not create override files; it only owns the convention. Overrides cannot grant what a skill's safety rules forbid (skipping hooks or tests, force-pushing, exfiltrating secrets).
 
 ## Workflow
 
@@ -81,6 +100,7 @@ List what CI already runs (`.github/workflows/*.yml`) and prefer commands that m
 2. Labels: install the full taxonomy above (recommended), keep a subset, or disable labels entirely.
 3. QA gate on or off. Recommend on when the repo ships user-facing changes.
 4. Optional repo-local review checklist path.
+5. Generate `SDLC.md` (recommended) and, when the repo has no agent instruction file, an `AGENTS.md` starter.
 
 ### 4. Create missing labels
 
@@ -118,18 +138,24 @@ gh label create risk-high         --color b60205 --description "Wide blast radiu
 
 Skip creation for labels that already exist. Never delete or recolor existing labels without being asked.
 
-### 5. Write and commit the config
+### 5. Generate the project docs
+
+Per the Project docs section above: write `SDLC.md` from `references/sdlc-template.md` with every placeholder resolved from the config and the answers given, and — only when the repo has no `AGENTS.md`/`CLAUDE.md`/equivalent — the starter `AGENTS.md`. Show both to the user before writing. Never overwrite an existing process doc or agent instruction file.
+
+### 6. Write and commit the config
 
 Write `.ai/agentic.config.json`, create `paths.runs` and `paths.analysis` directories with a `.gitkeep` each, show the final file to the user, and offer to commit:
 
 ```bash
-git add .ai/agentic.config.json .ai/runs/.gitkeep .ai/analysis/.gitkeep
+git add .ai/agentic.config.json .ai/runs/.gitkeep .ai/analysis/.gitkeep SDLC.md
 git commit -m "chore: configure agent PR pipeline"
 ```
 
-### 6. Report
+Include `AGENTS.md` in the commit when it was generated this run.
 
-Tell the user which skills are now unlocked and that the collection's entry points are `auto-create-pr` (ship a task as a PR), `auto-review-pr` (review a PR), and `merge-buddy` (what can merge now).
+### 7. Report
+
+Tell the user which skills are now unlocked and that the collection's entry points are `auto-create-pr` (ship a task as a PR), `auto-review-pr` (review a PR), and `merge-buddy` (what can merge now). Point at `SDLC.md` as the process reference for humans and at `.ai/agentic-overrides/` as the way to customize any single skill.
 
 ## The standard config-loading snippet
 
@@ -151,7 +177,10 @@ RUNS_DIR=$(jq -r '.paths.runs // ".ai/runs"' "$CONFIG")
 ANALYSIS_DIR=$(jq -r '.paths.analysis // ".ai/analysis"' "$CONFIG")
 LABELS_ENABLED=$(jq -r '.labels.enabled // false' "$CONFIG")
 QA_GATE=$(jq -r '.qaGate // false' "$CONFIG")
+TRACKER=$(jq -r '.tracker // "github"' "$CONFIG")
 ```
+
+Right after loading the config, a skill checks for its local override file (`.ai/agentic-overrides/<skill-name>.md`, see Per-skill local overrides) and reads the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics before doing any work.
 
 Label operations always go through an existence guard, so a missing label degrades to a logged skip instead of a failure:
 
@@ -174,5 +203,7 @@ apply_label() {
 
 - Never write the config without showing the user what was detected, unless `--defaults` was passed.
 - Never delete, rename, or recolor existing labels.
+- Never overwrite an existing `AGENTS.md`, `CLAUDE.md`, `SDLC.md`, or other process/instruction doc; generate only what is missing, and show it before writing.
 - Never store secrets, tokens, or user identities in the config file.
 - Keep the config committed; it is team configuration, not personal preference.
+- A `tracker` value with no matching provider skill is an error — stop and say so; do not improvise tracker calls.

--- a/skills/setup-agent-pipeline/references/sdlc-template.md
+++ b/skills/setup-agent-pipeline/references/sdlc-template.md
@@ -1,0 +1,113 @@
+<!--
+  Template for SDLC.md, consumed by the setup-agent-pipeline skill.
+  When generating the repo-local SDLC.md:
+  - Replace {{baseBranch}}, {{tracker}}, and {{validationCommands}} with values
+    resolved from .ai/agentic.config.json. Render {{validationCommands}} as a
+    bullet list of the configured commands, in order.
+  - Resolve every conditional block marked "IF <condition>" ... "END IF": keep
+    the content when the config condition is true, delete it entirely when
+    false, and strip the marker comments either way.
+  - Delete this instruction comment from the generated file.
+-->
+
+# Software delivery process
+
+## Purpose
+
+This file documents how work flows from ticket to merged PR in this repository. The agent skills configured in `.ai/agentic.config.json` enforce the process; humans read it here. PRs target `{{baseBranch}}`; issues and PRs live in {{tracker}}.
+
+Work enters through two paths: a free-form task brief handed to an agent, or a filed ticket. Both converge on the same review loop, the same validation gate, and the same merge gates.
+
+## Roles
+
+- **Author** — the human or agent who writes the change. Owns the ticket from claim to a merge-ready PR.
+- **Reviewer** — reads the diff and approves or requests changes. May be a human or the `auto-review-pr` skill; the `code-review` checklist applies either way.
+<!-- IF qaGate -->
+- **QA reviewer** — manually exercises user-facing changes before they merge. Always referenced by role, never by name or handle: assignments change.
+<!-- END IF -->
+- **Maintainer** — owns branch protection, the label taxonomy, the config, and this document; arbitrates when gates conflict.
+
+## Ticket lifecycle
+
+| Stage | What happens | Driven by | Done when |
+|---|---|---|---|
+| Intake | A ticket or task brief is filed in {{tracker}} with enough detail to act on. | Anyone | Ticket exists |
+| Triage | Confirm the issue is real, still unfixed on `{{baseBranch}}`, and not already claimed or covered by an open PR. Read-only; stops the chain cleanly when there is nothing to do. | `verify-in-repo` or a human | Confirmed actionable, or closed as no-action |
+| Claim | The author claims the ticket so concurrent agents back off. See the claim protocol below. | `apply-fix` / `auto-create-pr`, or a human | Claim visible on the ticket |
+| Implement | Locate the minimal change surface (`root-cause`, read-only), then implement the change with regression tests and run the validation gate. Task briefs without a ticket go through `auto-create-pr`, which plans, implements phase by phase in an isolated worktree, and runs the same gate. | `root-cause` + `apply-fix`, `auto-create-pr`, or a human author | Change complete, validation gate green |
+| PR | Commit, push, and open a PR against `{{baseBranch}}` with normalized labels. On a hand-worked branch, `check-and-commit` runs the gate, fixes obvious drift, and pushes when green. | `open-pr`, `auto-create-pr`, or `check-and-commit` | Open, labeled PR |
+| Review loop | The reviewer reads the diff against the `code-review` checklist and approves or requests changes. Requested changes are addressed (`auto-continue-pr` resumes agent PRs from the tracking plan) and the PR is re-reviewed until approved. | `auto-review-pr` (single PR), `review-prs` (sweep), or a human | Approving review submitted |
+<!-- IF qaGate -->
+| QA | A PR carrying `needs-qa` waits for manual QA. A QA reviewer tests it and records the outcome. See the QA gate below. | QA reviewer (manual) | `qa-approved` applied, or `qa-failed` routes it back |
+<!-- END IF -->
+| Merge | `merge-buddy` reports, read-only, which PRs can merge now and which are close but blocked. `approve-merge-pr` re-checks every gate, approves, and squash-merges. | `merge-buddy` + `approve-merge-pr`, or a human | PR squash-merged into `{{baseBranch}}` |
+| Post-merge housekeeping | Close issues the merged PR fixes; comment on issues whose PRs were closed without merging; turn leftover asks or review comments into tracked follow-up issues. | `sync-merged-pr-issues`, `followup-issue-from-pr` | Tracker reconciled, follow-ups filed |
+
+<!-- IF labels.enabled -->
+## Label state machine
+
+Pipeline labels are mutually exclusive: a PR carries at most one, and it names where the PR sits in the flow.
+
+- A ready, non-draft PR carries `review`.
+- The reviewer moves it: request changes → `changes-requested`; after fixes it returns to `review`; approval → `merge-queue`.
+- `merge-queue` is routing, not proof of QA: a `needs-qa` PR legitimately sits there until QA signs off.
+- Only a QA reviewer sets the `qa` pipeline label. They move a queued `needs-qa` PR from `merge-queue` to `qa` while testing, then back to `merge-queue` with `qa-approved` on pass, or to `qa-failed` on failure. Automated skills request QA with `needs-qa`; they never set `qa`.
+- `blocked` and `do-not-merge` are set and cleared by humans and stop the flow wherever it is.
+
+| Group | Labels | Exclusivity | Meaning |
+|---|---|---|---|
+| Pipeline | `review`, `changes-requested`, `qa`, `qa-failed`, `merge-queue`, `blocked`, `do-not-merge` | one at a time | Workflow state |
+| Category | `bug`, `feature`, `refactor`, `security`, `dependencies`, `documentation` | additive | Kind of change |
+| Meta | `needs-qa`, `skip-qa`, `qa-approved`, `qa-self-verified`, `in-progress` | additive | Process signals |
+| Priority | `priority-low`, `priority-medium`, `priority-high`, `priority-extreme` | one at a time; unset = medium | Urgency of the work |
+| Risk | `risk-low`, `risk-medium`, `risk-high` | one at a time; unset = medium | Blast radius of the change |
+
+Priority is how urgent the work is; risk is how dangerous the change is to ship. A one-line fix for an outage can be `priority-extreme` and `risk-low`; a large auth refactor that can wait can be `priority-low` and `risk-high`. A PR inherits both from its source issue unless the scope clearly changed. When an automated skill adds or changes a pipeline or meta label, it leaves a short comment explaining why.
+
+When no priority label is set, infer one:
+
+- `priority-extreme` — production outage, data loss, or an active security incident.
+- `priority-high` — security hardening or a release-blocking regression.
+- `priority-medium` — ordinary bug fixes and net-new features (also the default reading of unset).
+- `priority-low` — cosmetic, docs-only, dependency bumps, follow-up cleanup.
+
+When no risk label is set, infer one:
+
+- `risk-high` — auth, sessions, data scoping, money, schema migrations, shared contract surfaces, or broad cross-cutting edits.
+- `risk-medium` — an ordinary single-area change that ships with tests (also the default reading of unset).
+- `risk-low` — docs-only, test-only, typo, or isolated cosmetic changes.
+
+When signals conflict, pick the higher label and say why in the label comment. A `risk-high` PR strengthens the case for `needs-qa` and deeper review even when it would otherwise look routine.
+
+One label lives outside this taxonomy: `do-not-close`, applied by humans to issues that housekeeping skills must never auto-close. Skills only ever read it.
+<!-- END IF -->
+
+<!-- IF qaGate -->
+## The QA gate
+
+The one hard rule of this process: **a PR carrying `needs-qa` must not merge until it also carries `qa-approved`, even when every other check is green.** `merge-buddy` classifies such a PR as blocked; `approve-merge-pr` refuses to merge it.
+
+- Apply `needs-qa` to UI changes, new features, and other user-facing behavior that needs manual exercise.
+- `skip-qa` is the explicit opt-out for docs-only, dependency-only, CI-only, test-only, and similarly low-risk non-user-facing changes. Never combine it with `needs-qa`.
+- `qa-failed`, `do-not-merge`, and `blocked` are hard blocks regardless of every other signal. An active `qa` pipeline label means a tester is on the PR right now — never merge under an active tester.
+- The gate is satisfied when a QA reviewer tests the PR and applies `qa-approved`.
+- **Self-QA exception**: when no QA reviewer has capacity in time, any engineer may sign off instead — but only by (1) checking the PR out and running it locally, (2) exercising the affected flow, and (3) attaching evidence to the PR: a screenshot of it working, or a written account of what was exercised and the observed result. Then apply both `qa-approved` (so the gate passes) and `qa-self-verified` (so the exception is auditable). No evidence, no `qa-approved`.
+<!-- END IF -->
+
+## The claim protocol
+
+Before mutating an issue or PR, an agent claims it with all three signals: it assigns itself, adds the `in-progress` label, and posts a claim comment saying what it is doing. Any agent that finds an existing claim backs off instead of colliding. A PR carrying `in-progress` is also skipped by the merge tooling.
+
+The claim is released when the work finishes — on success and on failure alike. A stale `in-progress` with no recent activity may be cleared by the maintainer.
+
+## Validation gate
+
+Every PR passes the full validation gate before review sign-off, in this order:
+
+{{validationCommands}}
+
+Any non-zero exit fails the gate and blocks the PR. The implementing skills run the gate before opening a PR, and `check-and-commit` runs it before pushing a hand-worked branch. The command list lives in `.ai/agentic.config.json`; when it changes, update it there and in this section together.
+
+## Amending this process
+
+This document and `.ai/agentic.config.json` describe the same process: change them together, and re-run the `setup-agent-pipeline` skill when the toolchain or label taxonomy changes. Per-skill deviations — extra review rules, a different PR body template, an added gate step — belong in `.ai/agentic-overrides/<skill-name>.md`, which the named skill applies on top of its own instructions; local rules win, but overrides cannot grant what a skill's safety rules forbid.

--- a/skills/sync-merged-pr-issues/SKILL.md
+++ b/skills/sync-merged-pr-issues/SKILL.md
@@ -24,7 +24,7 @@ Maintenance skill. Walk a window of recent pull requests; where a PR authoritati
 
 ### 0. Load pipeline config and pre-flight
 
-Load `.ai/agentic.config.json` using the standard snippet from the `setup-agent-pipeline` skill. If the file is missing, stop and tell the user to run `setup-agent-pipeline` first. This resolves `BASE_BRANCH` (the configured base branch, with `"auto"` resolved from the repository's default branch) and `LABELS_ENABLED`.
+Load `.ai/agentic.config.json` using the standard snippet from the `setup-agent-pipeline` skill. If the file is missing, stop and tell the user to run `setup-agent-pipeline` first. This resolves `BASE_BRANCH` (the configured base branch, with `"auto"` resolved from the repository's default branch) and `LABELS_ENABLED`. Right after loading the config, check for `.ai/agentic-overrides/sync-merged-pr-issues.md`; when present, apply it on top of these instructions — local rules win, but an override can never relax this skill's safety rules. Also consult the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics.
 
 ```bash
 CURRENT_USER=$(gh api user --jq '.login')

--- a/skills/verify-in-repo/SKILL.md
+++ b/skills/verify-in-repo/SKILL.md
@@ -16,7 +16,7 @@ If you say go, the next step (`root-cause`) reads the code; then `apply-fix` mak
 
 ## Load pipeline config
 
-This step needs only the base branch. Resolve it from `.ai/agentic.config.json` per the standard snippet in the `setup-agent-pipeline` skill (only the `baseBranch` field is used here). If the config file is missing, stop and tell the user to run `setup-agent-pipeline` first.
+This step needs only the base branch. Resolve it from `.ai/agentic.config.json` per the standard snippet in the `setup-agent-pipeline` skill (only the `baseBranch` field is used here). If the config file is missing, stop and tell the user to run `setup-agent-pipeline` first. Right after loading the config, check for `.ai/agentic-overrides/verify-in-repo.md`; when present, apply it on top of these instructions — local rules win, but an override can never relax this skill's safety rules. Also consult the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics.
 
 ```bash
 CONFIG=.ai/agentic.config.json


### PR DESCRIPTION
#1 was merged before this landed on its branch, so the feedback round ships as its own PR. It folds in the five maintainer notes on the plan, each in a v1-light form:

1. **AGENTS.md as the project-specifics carrier.** Every skill now reads the repo's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) before working — installing into a repo with rich agent docs (including Open Mercato itself) is a drop-in with zero upstream changes. `setup-agent-pipeline` offers a starter `AGENTS.md` when the repo has none. The lint-gate change this required is documented in DECISIONS.md: the `AGENTS.md` token ban was replaced with a ban on the upstream-specific concept it was guarding against.

2. **Tracker abstraction — GitHub default, extensible.** New `tracker: "github"` config field plus a provider contract in `setup-agent-pipeline`: one skill per provider implementing the full issue/PR state-operations set, exactly to avoid micro-skill context pollution. v1 ships GitHub inline via `gh`; extracting `tracker-github` and adding `tracker-linear` is deferred until a second provider makes the indirection pay for itself.

3. **Install defaults to all skills.** README quickstart now leads with `npx skills add open-mercato/skills --skill '*'`, with interactive cherry-picking as the noted alternative.

4. **SDLC.md.** `setup-agent-pipeline` now generates a repo-local `SDLC.md` from `references/sdlc-template.md`: lifecycle stages mapped to the driving skills, the label state machine, the QA gate with the self-QA exception, the claim protocol, the validation gate — parameterized by base branch, tracker, label mode, and QA-gate setting.

5. **Skill inheritance / overrides.** New convention: `.ai/agentic-overrides/<skill-name>.md`. Every skill checks for its override file right after loading the config and applies it on top of its own instructions — local rules win, but overrides can never relax a skill's safety rules. Chosen over an `@`-include mechanism because include semantics differ across coding agents while "read this file and honor it" is portable.

Lint gate green. One commit, cherry-picked from the original branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
