### PR TITLE
refactor: rename om-auto-fix-github → om-auto-fix-issue

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -14,7 +14,7 @@ This repository solves a different problem: public adoption outside the Open Mer
 
 ## Naming
 
-The skills keep their upstream `om-*` names (`om-auto-create-pr`, `om-fix`, `om-auto-fix-github`, …). An earlier revision dropped the prefix; it came back deliberately, for drop-in compatibility with the upstream monorepo: with identical names, a repo that already keeps specialized versions under `.ai/skills/om-*` shadows the installed skills automatically via the repo-local override convention (see Project fit below), and existing slash-command muscle memory keeps working. The one skill with no upstream counterpart, `om-setup-agent-pipeline`, takes the prefix for consistency.
+The skills keep their upstream `om-*` names (`om-auto-create-pr`, `om-fix`, …). An earlier revision dropped the prefix; it came back deliberately, for drop-in compatibility with the upstream monorepo: with identical names, a repo that already keeps specialized versions under `.ai/skills/om-*` shadows the installed skills automatically via the repo-local override convention (see Project fit below), and existing slash-command muscle memory keeps working. The one skill with no upstream counterpart, `om-setup-agent-pipeline`, takes the prefix for consistency. One deliberate divergence from upstream naming: upstream `om-auto-fix-github` is `om-auto-fix-issue` here — with the tracker provider layer the skill fixes issues from any configured tracker, so the GitHub-specific name would misdescribe it. In a drop-in install the upstream monorepo keeps its own `om-auto-fix-github` alongside; the two do not shadow each other.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The installer never touches skills it does not own: an existing real directory (
 
 ## 🔁 The pipeline
 
-Two entry paths: hand the agent a task brief (`om-auto-create-pr`), or hand it a GitHub issue (`om-auto-fix-github`, which drives the autofix chain). Both converge on the same review loop and the same QA gate. Skills claim PRs and issues with an `in-progress` label, so concurrent agents back off instead of colliding.
+Two entry paths: hand the agent a task brief (`om-auto-create-pr`), or hand it a GitHub issue (`om-auto-fix-issue`, which drives the autofix chain). Both converge on the same review loop and the same QA gate. Skills claim PRs and issues with an `in-progress` label, so concurrent agents back off instead of colliding.
 
 ```mermaid
 flowchart LR
@@ -79,7 +79,7 @@ flowchart LR
         qaGate -- "needs-qa" --> manualQA["manual QA"]
         manualQA -- "qa-approved" --> mergePR
     end
-    subgraph issue ["From a GitHub issue: om-auto-fix-github drives the autofix chain"]
+    subgraph issue ["From a GitHub issue: om-auto-fix-issue drives the autofix chain"]
         verifyStep["om-verify-in-repo"] --> rootCause["om-root-cause"]
         rootCause --> applyFix["om-fix"]
         applyFix --> openPR["om-open-pr"]
@@ -96,7 +96,7 @@ Hand these a brief, an issue, or nothing at all — they run end-to-end without 
 | Skill | What it does autonomously |
 |---|---|
 | `om-auto-create-pr` | Takes a free-form task brief end-to-end: execution plan, isolated worktree, phase-by-phase commits, validation gate, self-review, labeled PR, then an autofix review loop until clean. Resumable. |
-| `om-auto-fix-github` | Fixes a tracker issue end-to-end by driving the autofix chain: triage gate, root-cause analysis, minimal fix with regression tests, labeled draft PR, autofix review loop. Stops cleanly when the issue is already solved or claimed. |
+| `om-auto-fix-issue` | Fixes a tracker issue end-to-end by driving the autofix chain: triage gate, root-cause analysis, minimal fix with regression tests, labeled draft PR, autofix review loop. Stops cleanly when the issue is already solved or claimed. |
 | `om-auto-continue-pr` | Resumes an in-progress PR from the first unchecked step in its tracking plan and carries it to completion — implementation, validation, review loop, summary comment. |
 | `om-auto-review-pr` | Reviews a PR by number in an isolated worktree, approves or requests changes, manages labels. On changes-requested, its autofix loop iterates fixes and re-review until merge-ready. |
 | `om-review-prs` | Sweeps all unreviewed open PRs, newest first, through `om-auto-review-pr`, respecting claim locks. |

--- a/skills/om-auto-fix-issue/SKILL.md
+++ b/skills/om-auto-fix-issue/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: om-auto-fix-github
+name: om-auto-fix-issue
 description: Fix a tracker issue end to end (GitHub issue by default) from a single command. Drives the autofix chain interactively — proves the issue still needs work (om-verify-in-repo), locates the bug (om-root-cause), implements the minimal fix with regression tests (om-fix), opens a labeled draft PR (om-open-pr), then loops om-auto-review-pr in autofix mode until clean. Runs in an isolated worktree, honors the in-progress claim protocol, and stops cleanly when the issue is already solved or already claimed.
 ---
 
-# Auto Fix GitHub
+# Auto Fix Issue
 
 Fix a tracker issue end to end without disturbing the user's active worktree. This skill is the interactive driver of the autofix chain (`om-verify-in-repo` → `om-root-cause` → `om-fix` → `om-open-pr` → `om-auto-review-pr`): it makes the go/no-go decision, prepares an isolated worktree, runs each chain step in sequence, and passes every step's output to the next exactly as the chain contract expects. The chain skills stay runnable on their own under an external flow runner; this skill is that runner for a single session.
 
@@ -17,7 +17,7 @@ Fix a tracker issue end to end without disturbing the user's active worktree. Th
 
 ### 0. Load pipeline config
 
-Load `.ai/agentic.config.json` using the standard snippet from the `om-setup-agent-pipeline` skill; the snippet also resolves `TRACKER` and `TRACKER_FILE=".ai/trackers/${TRACKER}.md"`. If the config or the tracker descriptor is missing, stop and tell the user to run `om-setup-agent-pipeline` first. Read `$TRACKER_FILE`; every tracker operation named in this skill executes as that descriptor defines, and the label guards (`label_exists`, `apply_issue_label`, `remove_issue_label`, …) come from it. This skill uses `BASE_BRANCH` and `LABELS_ENABLED` directly (plus the `label_exists` guard); the chain skills it invokes load the rest of the config themselves. Right after loading the config, check for a repo-local skill of the same name at `.ai/skills/om-auto-fix-github/SKILL.md`; when present, follow it instead of these instructions — a local skill that only extends this one can `@`-import or reference it and add its own rules on top. Local rules win, but a repo-local skill can never relax this skill's safety rules. Also consult the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics.
+Load `.ai/agentic.config.json` using the standard snippet from the `om-setup-agent-pipeline` skill; the snippet also resolves `TRACKER` and `TRACKER_FILE=".ai/trackers/${TRACKER}.md"`. If the config or the tracker descriptor is missing, stop and tell the user to run `om-setup-agent-pipeline` first. Read `$TRACKER_FILE`; every tracker operation named in this skill executes as that descriptor defines, and the label guards (`label_exists`, `apply_issue_label`, `remove_issue_label`, …) come from it. This skill uses `BASE_BRANCH` and `LABELS_ENABLED` directly (plus the `label_exists` guard); the chain skills it invokes load the rest of the config themselves. Right after loading the config, check for a repo-local skill of the same name at `.ai/skills/om-auto-fix-issue/SKILL.md`; when present, follow it instead of these instructions — a local skill that only extends this one can `@`-import or reference it and add its own rules on top. Local rules win, but a repo-local skill can never relax this skill's safety rules. Also consult the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics.
 
 ### 1. Decide whether you may take the issue
 
@@ -59,7 +59,7 @@ Never implement the fix in the repository's primary worktree.
 REPO_ROOT=$(git rev-parse --show-toplevel)
 GIT_DIR=$(git rev-parse --git-dir)
 GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
-WORKTREE_PARENT="$REPO_ROOT/.ai/tmp/om-auto-fix-github"
+WORKTREE_PARENT="$REPO_ROOT/.ai/tmp/om-auto-fix-issue"
 CREATED_WORKTREE=0
 
 if [ "$GIT_DIR" != "$GIT_COMMON_DIR" ]; then
@@ -143,7 +143,7 @@ If `om-auto-review-pr` cannot run (checks not yet reported, missing context), sk
 If the run aborts anywhere after `om-fix` claimed the issue but before `om-open-pr` released the lock, release it yourself — treat this as a finally-block, so a crash still clears it. Run the tracker operation **unlabel-issue** to remove the `in-progress` label from `{issueId}` — through the guard, so `LABELS_ENABLED=false` or a missing label degrades to a skip, and tolerate failure rather than aborting the cleanup. Then run **comment-issue** on `{issueId}` with exactly this abort comment:
 
 ```
-🤖 `om-auto-fix-github` aborted: {one-line reason}. Lock released.
+🤖 `om-auto-fix-issue` aborted: {one-line reason}. Lock released.
 ```
 
 Keep the assignee as-is on the failure path — a human picking the issue up can see who last worked on it.

--- a/skills/om-fix/SKILL.md
+++ b/skills/om-fix/SKILL.md
@@ -5,7 +5,7 @@ description: Implements the minimal code change identified by the om-root-cause 
 
 # Apply Fix
 
-You are step 3 of an autofix chain (`om-verify-in-repo` → `om-root-cause` → `om-fix` → `om-open-pr` → `om-auto-review-pr`). The chain is driven end-to-end by the `om-auto-fix-github` skill, or by an external flow runner. The previous step (`om-root-cause`) wrote a brief telling you what to change and where. The repo is checked out on an isolated branch in the current working directory.
+You are step 3 of an autofix chain (`om-verify-in-repo` → `om-root-cause` → `om-fix` → `om-open-pr` → `om-auto-review-pr`). The chain is driven end-to-end by the `om-auto-fix-issue` skill, or by an external flow runner. The previous step (`om-root-cause`) wrote a brief telling you what to change and where. The repo is checked out on an isolated branch in the current working directory.
 
 Your job: implement the proposed change, prove it works, and stop. The next step (`om-open-pr`) handles commit/push/PR.
 

--- a/skills/om-open-pr/SKILL.md
+++ b/skills/om-open-pr/SKILL.md
@@ -5,7 +5,7 @@ description: Commits the worktree's changes, pushes the autofix branch, opens a 
 
 # Open PR
 
-You are step 4 of an autofix chain (`om-verify-in-repo` → `om-root-cause` → `om-fix` → `om-open-pr` → `om-auto-review-pr`). The chain is driven end-to-end by the `om-auto-fix-github` skill, or by an external flow runner. The previous step (`om-fix`) edited files, added tests, and ran the validation gate. The repo is checked out on an isolated branch in the current working directory, with uncommitted changes staged or unstaged.
+You are step 4 of an autofix chain (`om-verify-in-repo` → `om-root-cause` → `om-fix` → `om-open-pr` → `om-auto-review-pr`). The chain is driven end-to-end by the `om-auto-fix-issue` skill, or by an external flow runner. The previous step (`om-fix`) edited files, added tests, and ran the validation gate. The repo is checked out on an isolated branch in the current working directory, with uncommitted changes staged or unstaged.
 
 Your job: ship the work — commit, push, open the PR, hand off — then release the lock. **You must end your message with the `PR_URL=` and `PR_NUMBER=` markers** so the review step has something to reference.
 

--- a/skills/om-root-cause/SKILL.md
+++ b/skills/om-root-cause/SKILL.md
@@ -5,7 +5,7 @@ description: Read-only root-cause analysis for a tracker issue. Identifies the b
 
 # Root Cause
 
-You are step 2 of an autofix chain (`om-verify-in-repo` → `om-root-cause` → `om-fix` → `om-open-pr` → `om-auto-review-pr`). The chain is driven end-to-end by the `om-auto-fix-github` skill, or by an external flow runner. The previous step (`om-verify-in-repo`) already confirmed this is a real defect. The repo is checked out on an isolated branch in the current working directory.
+You are step 2 of an autofix chain (`om-verify-in-repo` → `om-root-cause` → `om-fix` → `om-open-pr` → `om-auto-review-pr`). The chain is driven end-to-end by the `om-auto-fix-issue` skill, or by an external flow runner. The previous step (`om-verify-in-repo`) already confirmed this is a real defect. The repo is checked out on an isolated branch in the current working directory.
 
 Your only job: find the root cause and define the minimal change set. The next step (`om-fix`) implements what you propose — keep that agent on rails by being specific.
 

--- a/skills/om-verify-in-repo/SKILL.md
+++ b/skills/om-verify-in-repo/SKILL.md
@@ -5,7 +5,7 @@ description: Read-only triage gate for an autofix chain. Decides whether a track
 
 # Verify in Repo
 
-You are step 1 of an autofix chain (`om-verify-in-repo` → `om-root-cause` → `om-fix` → `om-open-pr` → `om-auto-review-pr`). The chain is driven end-to-end by the `om-auto-fix-github` skill, or by an external flow runner. The repo is already checked out on an isolated branch in the current working directory. Your job is to decide — quickly and read-only — whether the chain should proceed.
+You are step 1 of an autofix chain (`om-verify-in-repo` → `om-root-cause` → `om-fix` → `om-open-pr` → `om-auto-review-pr`). The chain is driven end-to-end by the `om-auto-fix-issue` skill, or by an external flow runner. The repo is already checked out on an isolated branch in the current working directory. Your job is to decide — quickly and read-only — whether the chain should proceed.
 
 If you say go, the next step (`om-root-cause`) reads the code; then `om-fix` makes edits; then `om-open-pr` pushes and opens a PR. If you say stop, none of that runs.
 


### PR DESCRIPTION
> Stacked on #6 (→ #5). GitHub retargets automatically as the stack merges; merge order: #5 → #6 → this.

Renames the autofix-chain orchestrator: with the tracker provider layer it fixes issues from **any** configured tracker (GitHub, Linear, …), so the GitHub-specific name misdescribed it.

Changed everywhere:
- `skills/om-auto-fix-github/` → `skills/om-auto-fix-issue/` (frontmatter name, H1 title, worktree path `.ai/tmp/om-auto-fix-issue`, abort-comment template, repo-local override path).
- Cross-references in the four chain skills (`om-verify-in-repo`, `om-root-cause`, `om-fix`, `om-open-pr`), the README pipeline diagram + autonomous-skills catalog row, and DECISIONS.md.
- DECISIONS Naming section now records this as the one deliberate divergence from upstream naming (upstream keeps `om-auto-fix-github`; the two don't shadow each other in a drop-in install).

`bash scripts/lint.sh` green (frontmatter name == directory verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)