### PR TITLE
feat: om-stabilize-ci — drive a PR or branch to green CI (+ CI-run tracker ops)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -14,7 +14,7 @@ This repository solves a different problem: public adoption outside the Open Mer
 
 ## Naming
 
-The skills keep their upstream `om-*` names (`om-auto-create-pr`, `om-fix`, `om-auto-fix-github`, …). An earlier revision dropped the prefix; it came back deliberately, for drop-in compatibility with the upstream monorepo: with identical names, a repo that already keeps specialized versions under `.ai/skills/om-*` shadows the installed skills automatically via the repo-local override convention (see Project fit below), and existing slash-command muscle memory keeps working. The one skill with no upstream counterpart, `om-setup-agent-pipeline`, takes the prefix for consistency.
+The skills keep their upstream `om-*` names (`om-auto-create-pr`, `om-fix`, …). An earlier revision dropped the prefix; it came back deliberately, for drop-in compatibility with the upstream monorepo: with identical names, a repo that already keeps specialized versions under `.ai/skills/om-*` shadows the installed skills automatically via the repo-local override convention (see Project fit below), and existing slash-command muscle memory keeps working. The one skill with no upstream counterpart, `om-setup-agent-pipeline`, takes the prefix for consistency. One deliberate divergence from upstream naming: upstream `om-auto-fix-github` is `om-auto-fix-issue` here — with the tracker provider layer the skill fixes issues from any configured tracker, so the GitHub-specific name would misdescribe it. In a drop-in install the upstream monorepo keeps its own `om-auto-fix-github` alongside; the two do not shadow each other.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The installer never touches skills it does not own: an existing real directory (
 
 ## 🔁 The pipeline
 
-Two entry paths: hand the agent a task brief (`om-auto-create-pr`), or hand it a GitHub issue (`om-auto-fix-github`, which drives the autofix chain). Both converge on the same review loop and the same QA gate. Skills claim PRs and issues with an `in-progress` label, so concurrent agents back off instead of colliding.
+Two entry paths: hand the agent a task brief (`om-auto-create-pr`), or hand it a GitHub issue (`om-auto-fix-issue`, which drives the autofix chain). Both converge on the same review loop and the same QA gate. Skills claim PRs and issues with an `in-progress` label, so concurrent agents back off instead of colliding.
 
 ```mermaid
 flowchart LR
@@ -79,7 +79,7 @@ flowchart LR
         qaGate -- "needs-qa" --> manualQA["manual QA"]
         manualQA -- "qa-approved" --> mergePR
     end
-    subgraph issue ["From a GitHub issue: om-auto-fix-github drives the autofix chain"]
+    subgraph issue ["From a GitHub issue: om-auto-fix-issue drives the autofix chain"]
         verifyStep["om-verify-in-repo"] --> rootCause["om-root-cause"]
         rootCause --> applyFix["om-fix"]
         applyFix --> openPR["om-open-pr"]
@@ -96,7 +96,7 @@ Hand these a brief, an issue, or nothing at all — they run end-to-end without 
 | Skill | What it does autonomously |
 |---|---|
 | `om-auto-create-pr` | Takes a free-form task brief end-to-end: execution plan, isolated worktree, phase-by-phase commits, validation gate, self-review, labeled PR, then an autofix review loop until clean. Resumable. |
-| `om-auto-fix-github` | Fixes a tracker issue end-to-end by driving the autofix chain: triage gate, root-cause analysis, minimal fix with regression tests, labeled draft PR, autofix review loop. Stops cleanly when the issue is already solved or claimed. |
+| `om-auto-fix-issue` | Fixes a tracker issue end-to-end by driving the autofix chain: triage gate, root-cause analysis, minimal fix with regression tests, labeled draft PR, autofix review loop. Stops cleanly when the issue is already solved or claimed. |
 | `om-auto-continue-pr` | Resumes an in-progress PR from the first unchecked step in its tracking plan and carries it to completion — implementation, validation, review loop, summary comment. |
 | `om-auto-review-pr` | Reviews a PR by number in an isolated worktree, approves or requests changes, manages labels. On changes-requested, its autofix loop iterates fixes and re-review until merge-ready. |
 | `om-review-prs` | Sweeps all unreviewed open PRs, newest first, through `om-auto-review-pr`, respecting claim locks. |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <b>🧠 plan · 🔨 implement · 🔍 review · ✅ QA gate · 🚢 merge</b><br/>
-  Nineteen agent skills that run a full PR pipeline. Install them into any repo, with any coding agent.
+  Twenty agent skills that run a full PR pipeline. Install them into any repo, with any coding agent.
 </p>
 
 <p align="center">
@@ -26,7 +26,7 @@ These skills wrote and shipped a real product. Inside the [Open Mercato](https:/
 npx skills add open-mercato/skills --skill '*'
 ```
 
-Install all nineteen — the pipeline composes, and every skill is small until invoked. Drop `--skill '*'` to cherry-pick interactively. Skills install for 22+ coding agents (Claude Code, Cursor, Codex, and others) via [skills.sh](https://skills.sh).
+Install all twenty — the pipeline composes, and every skill is small until invoked. Drop `--skill '*'` to cherry-pick interactively. Skills install for 22+ coding agents (Claude Code, Cursor, Codex, and others) via [skills.sh](https://skills.sh).
 
 Then, once per repository:
 
@@ -101,6 +101,7 @@ Hand these a brief, an issue, or nothing at all — they run end-to-end without 
 | `om-auto-review-pr` | Reviews a PR by number in an isolated worktree, approves or requests changes, manages labels. On changes-requested, its autofix loop iterates fixes and re-review until merge-ready. |
 | `om-review-prs` | Sweeps all unreviewed open PRs, newest first, through `om-auto-review-pr`, respecting claim locks. |
 | `om-sync-merged-pr-issues` | Post-merge housekeeping sweep: closes issues that merged PRs fix, comments on issues whose PRs were closed without merging. |
+| `om-stabilize-ci` | Drives a PR or branch to green CI: reads failing checks and their logs through tracker operations, classifies each failure (real bug / test bug / flake / infra), fixes with tests in an isolated worktree, pushes, and re-checks until every required check passes. Never fakes green. |
 
 ### 🧑‍💻 You invoke
 

--- a/skills/om-auto-fix-issue/SKILL.md
+++ b/skills/om-auto-fix-issue/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: om-auto-fix-github
+name: om-auto-fix-issue
 description: Fix a tracker issue end to end (GitHub issue by default) from a single command. Drives the autofix chain interactively — proves the issue still needs work (om-verify-in-repo), locates the bug (om-root-cause), implements the minimal fix with regression tests (om-fix), opens a labeled draft PR (om-open-pr), then loops om-auto-review-pr in autofix mode until clean. Runs in an isolated worktree, honors the in-progress claim protocol, and stops cleanly when the issue is already solved or already claimed.
 ---
 
-# Auto Fix GitHub
+# Auto Fix Issue
 
 Fix a tracker issue end to end without disturbing the user's active worktree. This skill is the interactive driver of the autofix chain (`om-verify-in-repo` → `om-root-cause` → `om-fix` → `om-open-pr` → `om-auto-review-pr`): it makes the go/no-go decision, prepares an isolated worktree, runs each chain step in sequence, and passes every step's output to the next exactly as the chain contract expects. The chain skills stay runnable on their own under an external flow runner; this skill is that runner for a single session.
 
@@ -17,7 +17,7 @@ Fix a tracker issue end to end without disturbing the user's active worktree. Th
 
 ### 0. Load pipeline config
 
-Load `.ai/agentic.config.json` using the standard snippet from the `om-setup-agent-pipeline` skill; the snippet also resolves `TRACKER` and `TRACKER_FILE=".ai/trackers/${TRACKER}.md"`. If the config or the tracker descriptor is missing, stop and tell the user to run `om-setup-agent-pipeline` first. Read `$TRACKER_FILE`; every tracker operation named in this skill executes as that descriptor defines, and the label guards (`label_exists`, `apply_issue_label`, `remove_issue_label`, …) come from it. This skill uses `BASE_BRANCH` and `LABELS_ENABLED` directly (plus the `label_exists` guard); the chain skills it invokes load the rest of the config themselves. Right after loading the config, check for a repo-local skill of the same name at `.ai/skills/om-auto-fix-github/SKILL.md`; when present, follow it instead of these instructions — a local skill that only extends this one can `@`-import or reference it and add its own rules on top. Local rules win, but a repo-local skill can never relax this skill's safety rules. Also consult the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics.
+Load `.ai/agentic.config.json` using the standard snippet from the `om-setup-agent-pipeline` skill; the snippet also resolves `TRACKER` and `TRACKER_FILE=".ai/trackers/${TRACKER}.md"`. If the config or the tracker descriptor is missing, stop and tell the user to run `om-setup-agent-pipeline` first. Read `$TRACKER_FILE`; every tracker operation named in this skill executes as that descriptor defines, and the label guards (`label_exists`, `apply_issue_label`, `remove_issue_label`, …) come from it. This skill uses `BASE_BRANCH` and `LABELS_ENABLED` directly (plus the `label_exists` guard); the chain skills it invokes load the rest of the config themselves. Right after loading the config, check for a repo-local skill of the same name at `.ai/skills/om-auto-fix-issue/SKILL.md`; when present, follow it instead of these instructions — a local skill that only extends this one can `@`-import or reference it and add its own rules on top. Local rules win, but a repo-local skill can never relax this skill's safety rules. Also consult the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics.
 
 ### 1. Decide whether you may take the issue
 
@@ -59,7 +59,7 @@ Never implement the fix in the repository's primary worktree.
 REPO_ROOT=$(git rev-parse --show-toplevel)
 GIT_DIR=$(git rev-parse --git-dir)
 GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
-WORKTREE_PARENT="$REPO_ROOT/.ai/tmp/om-auto-fix-github"
+WORKTREE_PARENT="$REPO_ROOT/.ai/tmp/om-auto-fix-issue"
 CREATED_WORKTREE=0
 
 if [ "$GIT_DIR" != "$GIT_COMMON_DIR" ]; then
@@ -143,7 +143,7 @@ If `om-auto-review-pr` cannot run (checks not yet reported, missing context), sk
 If the run aborts anywhere after `om-fix` claimed the issue but before `om-open-pr` released the lock, release it yourself — treat this as a finally-block, so a crash still clears it. Run the tracker operation **unlabel-issue** to remove the `in-progress` label from `{issueId}` — through the guard, so `LABELS_ENABLED=false` or a missing label degrades to a skip, and tolerate failure rather than aborting the cleanup. Then run **comment-issue** on `{issueId}` with exactly this abort comment:
 
 ```
-🤖 `om-auto-fix-github` aborted: {one-line reason}. Lock released.
+🤖 `om-auto-fix-issue` aborted: {one-line reason}. Lock released.
 ```
 
 Keep the assignee as-is on the failure path — a human picking the issue up can see who last worked on it.

--- a/skills/om-fix/SKILL.md
+++ b/skills/om-fix/SKILL.md
@@ -5,7 +5,7 @@ description: Implements the minimal code change identified by the om-root-cause 
 
 # Apply Fix
 
-You are step 3 of an autofix chain (`om-verify-in-repo` → `om-root-cause` → `om-fix` → `om-open-pr` → `om-auto-review-pr`). The chain is driven end-to-end by the `om-auto-fix-github` skill, or by an external flow runner. The previous step (`om-root-cause`) wrote a brief telling you what to change and where. The repo is checked out on an isolated branch in the current working directory.
+You are step 3 of an autofix chain (`om-verify-in-repo` → `om-root-cause` → `om-fix` → `om-open-pr` → `om-auto-review-pr`). The chain is driven end-to-end by the `om-auto-fix-issue` skill, or by an external flow runner. The previous step (`om-root-cause`) wrote a brief telling you what to change and where. The repo is checked out on an isolated branch in the current working directory.
 
 Your job: implement the proposed change, prove it works, and stop. The next step (`om-open-pr`) handles commit/push/PR.
 

--- a/skills/om-open-pr/SKILL.md
+++ b/skills/om-open-pr/SKILL.md
@@ -5,7 +5,7 @@ description: Commits the worktree's changes, pushes the autofix branch, opens a 
 
 # Open PR
 
-You are step 4 of an autofix chain (`om-verify-in-repo` → `om-root-cause` → `om-fix` → `om-open-pr` → `om-auto-review-pr`). The chain is driven end-to-end by the `om-auto-fix-github` skill, or by an external flow runner. The previous step (`om-fix`) edited files, added tests, and ran the validation gate. The repo is checked out on an isolated branch in the current working directory, with uncommitted changes staged or unstaged.
+You are step 4 of an autofix chain (`om-verify-in-repo` → `om-root-cause` → `om-fix` → `om-open-pr` → `om-auto-review-pr`). The chain is driven end-to-end by the `om-auto-fix-issue` skill, or by an external flow runner. The previous step (`om-fix`) edited files, added tests, and ran the validation gate. The repo is checked out on an isolated branch in the current working directory, with uncommitted changes staged or unstaged.
 
 Your job: ship the work — commit, push, open the PR, hand off — then release the lock. **You must end your message with the `PR_URL=` and `PR_NUMBER=` markers** so the review step has something to reference.
 

--- a/skills/om-root-cause/SKILL.md
+++ b/skills/om-root-cause/SKILL.md
@@ -5,7 +5,7 @@ description: Read-only root-cause analysis for a tracker issue. Identifies the b
 
 # Root Cause
 
-You are step 2 of an autofix chain (`om-verify-in-repo` → `om-root-cause` → `om-fix` → `om-open-pr` → `om-auto-review-pr`). The chain is driven end-to-end by the `om-auto-fix-github` skill, or by an external flow runner. The previous step (`om-verify-in-repo`) already confirmed this is a real defect. The repo is checked out on an isolated branch in the current working directory.
+You are step 2 of an autofix chain (`om-verify-in-repo` → `om-root-cause` → `om-fix` → `om-open-pr` → `om-auto-review-pr`). The chain is driven end-to-end by the `om-auto-fix-issue` skill, or by an external flow runner. The previous step (`om-verify-in-repo`) already confirmed this is a real defect. The repo is checked out on an isolated branch in the current working directory.
 
 Your only job: find the root cause and define the minimal change set. The next step (`om-fix`) implements what you propose — keep that agent on rails by being specific.
 

--- a/skills/om-setup-agent-pipeline/references/trackers/TEMPLATE.md
+++ b/skills/om-setup-agent-pipeline/references/trackers/TEMPLATE.md
@@ -63,6 +63,14 @@ Copy this file to `.ai/trackers/{name}.md`, set `"tracker": "{name}"` in `.ai/ag
 - **get-required-checks** — base branch → required status checks; when unreadable, treat all reported checks as required.
 - **get-pr-comment / get-review-comment** — comment id → body, author, URL (conversation vs inline review comment).
 
+### CI runs
+
+- **list-runs** — branch (or head SHA) → recent CI runs with id, workflow name, status, conclusion.
+- **get-run** — run id → status, conclusion, per-job breakdown.
+- **get-run-failed-logs** — run id → log output of the failed steps (the diagnosis input for CI failures).
+- **rerun-failed** — run id → re-execute only the failed jobs (used to disambiguate flakes before code changes).
+- **watch-run** — run id → block until the run completes, signaling success/failure; may degrade to polling **get-run**.
+
 ### Labels
 
 - **list-labels** — all label/tag names.

--- a/skills/om-setup-agent-pipeline/references/trackers/github.md
+++ b/skills/om-setup-agent-pipeline/references/trackers/github.md
@@ -257,6 +257,40 @@ gh api repos/{owner}/{repo}/issues/comments/{commentId} --jq '{body,user:.user.l
 gh api repos/{owner}/{repo}/pulls/comments/{commentId} --jq '{body,user:.user.login,url:.html_url}'
 ```
 
+### CI runs
+
+CI status for a *PR* comes from **get-pr-checks** / **get-required-checks** above. The operations here address CI runs directly — needed when working from a bare branch, or when a failure diagnosis needs the actual logs.
+
+#### list-runs
+Branch (or head SHA) → recent workflow runs with id, workflow name, status, and conclusion.
+```bash
+gh run list --branch {branch} --limit 20 --json databaseId,workflowName,name,status,conclusion,headSha,url,createdAt
+```
+
+#### get-run
+Run id → status, conclusion, and per-job breakdown.
+```bash
+gh run view {runId} --json status,conclusion,workflowName,headSha,url,jobs
+```
+
+#### get-run-failed-logs
+Run id → the log output of failed steps only. This is the primary diagnosis input for CI failures.
+```bash
+gh run view {runId} --log-failed
+```
+
+#### rerun-failed
+Run id → re-execute only the failed jobs of that run. Use to disambiguate flaky failures before changing any code.
+```bash
+gh run rerun {runId} --failed
+```
+
+#### watch-run
+Run id → block until the run completes, exiting non-zero on failure. Prefer this over sleep-polling; fall back to periodic **get-run** when watching is unavailable.
+```bash
+gh run watch {runId} --exit-status
+```
+
 ### Labels
 
 #### list-labels

--- a/skills/om-stabilize-ci/SKILL.md
+++ b/skills/om-stabilize-ci/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: om-stabilize-ci
+description: Drive a PR or branch to green CI. Reads check status through tracker operations, pulls failed-step logs, classifies each failure (real bug, test bug, flake, infra), fixes the real ones in an isolated worktree with tests, pushes, and re-checks — iterating until every required check passes or a genuine blocker is reported. Never goes green by weakening tests or disabling checks.
+---
+
+# Stabilize CI
+
+Given a PR number or a branch name, iterate until CI is green: read the failing checks, diagnose from the actual failure logs, apply minimal fixes with regression coverage, push, wait for the re-run, repeat. The one thing this skill will never do is *fake* green — deleting tests, loosening assertions, skipping steps, or disabling checks to pass is forbidden, and a repo-local override cannot relax that.
+
+## Arguments
+
+- `{prNumber}` **or** `--branch <name>` (one required) — the target. With `--branch`, if an open PR already exists for that branch, switch to PR mode (its claim protocol and summary comment apply). Bare-branch mode covers branches with no PR yet.
+- `--max-iterations <n>` (optional) — fix→push→re-check cycles before stopping with a report. Default: 5.
+- `--force` (optional) — bypass the in-progress claim check on the PR; use only when intentionally taking over.
+
+## Step 0 — Load pipeline config
+
+Load `.ai/agentic.config.json` using the standard snippet from the `om-setup-agent-pipeline` skill; the snippet also resolves `TRACKER` and `TRACKER_FILE=".ai/trackers/${TRACKER}.md"` — stop when either is missing. Read `$TRACKER_FILE`; every tracker operation named in this skill (**get-pr**, **get-pr-checks**, **get-required-checks**, **list-runs**, **get-run**, **get-run-failed-logs**, **rerun-failed**, **watch-run**, **comment-pr**, …) executes as that descriptor defines, and the label guards come from it. This skill uses `BASE_BRANCH`, `LABELS_ENABLED`, and `validation.commands`. Right after loading the config, check for a repo-local skill of the same name at `.ai/skills/om-stabilize-ci/SKILL.md`; when present, follow it instead of these instructions — a local skill that only extends this one can `@`-import or reference it and add its own rules on top. Local rules win, but a repo-local skill can never relax this skill's safety rules. Also consult the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics.
+
+## Workflow
+
+### 1. Resolve the target and claim it
+
+**PR mode**: run **get-pr** for `{prNumber}` requesting `number,title,state,headRefName,baseRefName,isCrossRepository,assignees,labels,comments,author,url`. Stop when the PR is not open. Apply the standard claim protocol: the PR is **already in progress** when it carries the `in-progress` label with a different assignee, has another assignee, or shows a `🤖`-prefixed claim comment newer than 30 minutes from another actor — stop and ask unless `--force` (stale locks older than 60 minutes with no pushes/comments count as expired). Then claim: **assign-pr** to the current user (via **current-user**), `apply_label "in-progress" {prNumber}` through the guard, and post via **comment-pr**:
+
+```text
+🤖 `om-stabilize-ci` started by @{CURRENT_USER} at {timestamp}. Other auto-skills will skip this PR until the lock is released.
+```
+
+**Branch mode**: run **list-prs** filtered to the branch as head; when an open PR exists, switch to PR mode with it. Otherwise proceed without a claim (there is nothing to lock) and note that in the report.
+
+### 2. Baseline: what is failing?
+
+- PR mode: **get-pr-checks** for `{prNumber}` (name, state, link) and **get-required-checks** for the base branch; when required checks are unreadable, treat all reported checks as required.
+- Branch mode: **list-runs** for the branch; take the newest run per workflow; **get-run** for the per-job breakdown.
+
+Classify every check as passing, pending, or failing. If nothing is failing and nothing is pending — report "already green" and go to step 7. If checks are pending, **watch-run** (or poll) until they settle before diagnosing.
+
+### 3. Prepare an isolated worktree
+
+Never work in the user's primary worktree. Reuse the current linked worktree when already inside one; never nest. Otherwise:
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+WORKTREE_PARENT="$REPO_ROOT/.ai/tmp/om-stabilize-ci"
+mkdir -p "$WORKTREE_PARENT"
+WORKTREE_DIR="$WORKTREE_PARENT/{target}-$(date +%Y%m%d-%H%M%S)"
+git fetch origin "$HEAD_REF"
+git worktree add "$WORKTREE_DIR" "$HEAD_REF"
+CREATED_WORKTREE=1
+```
+
+For cross-repository fork PRs, make the head available via **checkout-pr** first. Install dependencies per the repo's lockfile. Clean up the worktree in a `trap`/finally — only if this run created it.
+
+### 4. The stabilization loop (up to `--max-iterations`)
+
+Per iteration:
+
+1. **Collect evidence.** For every failing check, fetch the failed-step logs: resolve the run via **list-runs**/**get-run**, then **get-run-failed-logs**. Extract the first real error per job (assertion, compile error, stack trace), not the last noise line.
+2. **Classify each failure** into one primary bucket:
+   - **Real code bug** — the change (or the branch state) genuinely breaks behavior. Fix the code, add or extend a regression test.
+   - **Test bug** — stale locator/fixture, wrong assumption, nondeterminism in the test itself. Fix the *test's correctness*; never weaken what it proves.
+   - **Flake** — suspected when the failure is unrelated to the diff, timing-dependent, or historically intermittent. Before touching code, **rerun-failed** once. If it passes on rerun, record it as a flake — do not "fix" it blindly; note it for a follow-up issue (step 6).
+   - **Infra / out of scope** — runner outages, missing secrets, base branch already broken (verify by checking whether the same check fails on `origin/$BASE_BRANCH` via **list-runs** on the base branch). These are blockers, not fixables — record and move on; if every remaining failure is out of scope, stop with `Status: blocked`.
+3. **Reproduce locally** whenever the check maps to a local command — match the check name against `validation.commands` and the repo's scripts, and run the matching command in the worktree. Fix against the local reproduction; it is faster and proves the diagnosis.
+4. **Fix minimally.** No refactors, no scope creep, no drive-by cleanups. Respect the project's conventions from its agent instructions. Changes to CI workflow files are allowed only when the workflow itself is the bug (e.g. a wrong path filter) — never to remove, skip, or soften a check; flag any workflow edit prominently in the summary.
+5. **Validate locally**: run the targeted commands for what changed, and the full `validation.commands` gate when fixes span more than one area.
+6. **Commit and push**: one commit per logical fix, conventional subject (`fix(ci): …`, `fix(test): …`, `fix(<area>): …`). Never rewrite published history, never `--no-verify`, never force-push.
+7. **Wait for CI**: **watch-run** on the new runs (or poll **get-pr-checks**) until they settle. Green → step 5. Still failing → next iteration with the new evidence. A check that fails the same way twice after a targeted fix means the diagnosis is wrong — re-diagnose from scratch instead of stacking guesses.
+
+### 5. Exit conditions
+
+- **Green**: every required check passes (non-required failures are reported but do not block success — say so explicitly).
+- **Blocked**: remaining failures are all infra/out-of-scope, or `--max-iterations` is exhausted. Report `Status: blocked` with the per-check analysis — never leave it at "CI is still red".
+
+### 6. File follow-ups for flakes
+
+For each confirmed flake (failed, passed on rerun, unrelated to the diff), offer to file a tracked issue via the `om-followup-issue-from-pr` skill or **create-issue** directly: test name, failure signature, run link, and the rerun evidence. Flaky tests that go unrecorded get rediscovered the hard way.
+
+### 7. Report and release
+
+In PR mode, post a summary via **comment-pr** and release the lock — as a finally-block, even on failure:
+
+```markdown
+## 🤖 `om-stabilize-ci` — run summary
+
+**Target:** {PR #n / branch}   **Result:** {green | blocked | max-iterations}
+**Iterations:** {k}/{max}
+
+| Check | Initial failure | Classification | Action | Commit | Final state |
+|-------|-----------------|----------------|--------|--------|-------------|
+| {name} | {one-line error} | real bug / test bug / flake / infra | {fix summary or rerun} | {sha or —} | ✅ / ❌ |
+
+**Flakes recorded:** {issue links or none}
+**Workflow files touched:** {list or none — with justification}
+```
+
+Then remove `in-progress` through the guard (when `LABELS_ENABLED`) and post: `🤖 \`om-stabilize-ci\` completed: {result}. Lock released.` Run the worktree cleanup. Report the same summary to the user, plus the branch/PR link.
+
+## Rules
+
+- Never make CI green by deleting or skipping tests, loosening assertions, raising timeouts to mask real slowness, marking tests expected-to-fail, or removing/disabling checks and workflow steps. This is the skill's defining safety rule; repo-local overrides cannot relax it.
+- Always diagnose from the actual failed-step logs (**get-run-failed-logs**) — never guess from the check name alone.
+- Suspected flakes get one **rerun-failed** *before* any code change; a rerun-pass is recorded as a flake, not silently accepted.
+- Fixes are minimal and evidence-based; a fix that does not change the failure signature on the next run means the diagnosis was wrong — re-diagnose, do not stack guesses.
+- Failures that also occur on the base branch are out of scope — report them; do not fix unrelated base breakage from this branch.
+- Always work in an isolated worktree; reuse a linked worktree when already inside one; clean up what this run created.
+- PR mode follows the standard claim protocol and always releases the `in-progress` lock at the end, even on failure (trap/finally).
+- Never rewrite published history, never `--no-verify`, never force-push.
+- Every label mutation goes through the tracker descriptor's guards and honors `labels.enabled`.
+- Respect `--max-iterations` absolutely; when exhausted, stop with the full per-check analysis instead of looping forever.

--- a/skills/om-verify-in-repo/SKILL.md
+++ b/skills/om-verify-in-repo/SKILL.md
@@ -5,7 +5,7 @@ description: Read-only triage gate for an autofix chain. Decides whether a track
 
 # Verify in Repo
 
-You are step 1 of an autofix chain (`om-verify-in-repo` → `om-root-cause` → `om-fix` → `om-open-pr` → `om-auto-review-pr`). The chain is driven end-to-end by the `om-auto-fix-github` skill, or by an external flow runner. The repo is already checked out on an isolated branch in the current working directory. Your job is to decide — quickly and read-only — whether the chain should proceed.
+You are step 1 of an autofix chain (`om-verify-in-repo` → `om-root-cause` → `om-fix` → `om-open-pr` → `om-auto-review-pr`). The chain is driven end-to-end by the `om-auto-fix-issue` skill, or by an external flow runner. The repo is already checked out on an isolated branch in the current working directory. Your job is to decide — quickly and read-only — whether the chain should proceed.
 
 If you say go, the next step (`om-root-cause`) reads the code; then `om-fix` makes edits; then `om-open-pr` pushes and opens a PR. If you say stop, none of that runs.
 


### PR DESCRIPTION
> First commit re-lands the `om-auto-fix-issue` rename from #7, which hit the same stack mishap as #6 (merged into its base branch after that base had already landed on main, so it never reached `main`). This PR is based directly on `main` — no stacking this time.

## New skill: `om-stabilize-ci` (autonomous)

Given `{prNumber}` or `--branch <name>`, it iterates until CI is green:

1. **Baseline** — failing/pending/passing per check via **get-pr-checks** + **get-required-checks** (PR mode) or **list-runs**/**get-run** (bare-branch mode; auto-switches to PR mode when an open PR exists for the branch).
2. **Diagnose from evidence** — **get-run-failed-logs** per failing check; first real error, not the last noise line.
3. **Classify** — real code bug / test bug / flake / infra. Flakes get one **rerun-failed** *before* any code change; infra and base-branch breakage (verified against the base branch's own runs) are reported as out of scope, not "fixed".
4. **Fix minimally** in an isolated worktree, reproduce locally via `validation.commands` mapping, add regression coverage, conventional commits, push — never rewrite history, never `--no-verify`.
5. **Watch the re-run** and loop, up to `--max-iterations` (default 5). Same failure twice after a targeted fix ⇒ re-diagnose instead of stacking guesses.
6. **Report** — per-check table (initial failure → classification → action → commit → final state) as a PR comment + to the user; flakes offered as tracked follow-up issues; standard claim protocol with guaranteed lock release.

**Defining safety rule** (repo-local overrides cannot relax it): never go green by deleting/skipping tests, loosening assertions, masking slowness with timeouts, or disabling checks/workflow steps. Workflow-file edits are allowed only when the workflow itself is the bug, and are flagged in the summary.

## Tracker contract extension

`TEMPLATE.md` and the GitHub descriptor gain a **CI runs** section: **list-runs**, **get-run**, **get-run-failed-logs**, **rerun-failed**, **watch-run** — implemented with `gh run …` in the GitHub descriptor, definable per provider like every other operation.

README: autonomous-skills catalog row, counts to twenty. `bash scripts/lint.sh` green (incl. the gh-abstraction gate — the new `gh run` commands live only in the descriptor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)