### PR TITLE
docs: add paths.specs to the README config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ Nothing here assumes JavaScript, or any particular product. The base branch, the
   "qaGate": true,
   "paths": {
     "runs": ".ai/runs",
-    "analysis": ".ai/analysis"
+    "analysis": ".ai/analysis",
+    "specs": ".ai/specs"
   },
   "reviewChecklist": null
 }


### PR DESCRIPTION
> Stacked on #10 (the change documents the `paths.specs` key #10 introduces). Merge order: #9 → #10 → this; GitHub retargets automatically.

One-liner: the README's example `.ai/agentic.config.json` was missing `"specs": ".ai/specs"` in the `paths` block, out of sync with the schema in `om-setup-agent-pipeline`. Now matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)