### PR TITLE
docs+feat: UPGRADE_NOTES.md and om-apply-upgrade-notes — migrate repo-installed artifacts after skill upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ These skills wrote and shipped a real product. Inside the [Open Mercato](https:/
 npx skills add open-mercato/skills --skill '*'
 ```
 
-Install all twenty-five — the pipeline composes, and every skill is small until invoked. Drop `--skill '*'` to cherry-pick interactively. Skills install for 22+ coding agents (Claude Code, Cursor, Codex, and others) via [skills.sh](https://skills.sh).
+Install all twenty-six — the pipeline composes, and every skill is small until invoked. Drop `--skill '*'` to cherry-pick interactively. Skills install for 22+ coding agents (Claude Code, Cursor, Codex, and others) via [skills.sh](https://skills.sh).
 
 Then, once per repository:
 
@@ -44,7 +44,7 @@ Then ship something:
 
 The agent drafts an execution plan, implements it phase by phase in an isolated worktree, runs your validation commands, reviews its own diff, and opens a labeled, reviewed PR.
 
-**Upgrading later?** Skills auto-update on reinstall, but repo-installed artifacts — above all `.ai/trackers/<tracker>.md` — do not. See [UPGRADE_NOTES.md](UPGRADE_NOTES.md).
+**Upgrading later?** Skills auto-update on reinstall, but repo-installed artifacts — above all `.ai/trackers/<tracker>.md` — do not. Run `/om-apply-upgrade-notes` in the repo, or follow [UPGRADE_NOTES.md](UPGRADE_NOTES.md) by hand.
 
 ## 🛠️ Local development
 
@@ -114,6 +114,7 @@ Interactive helpers: they act once, report, and hand control back to you.
 | Skill | What it does |
 |---|---|
 | `om-setup-agent-pipeline` | One-per-repo configurator. Inspects the repository, asks a few questions, writes `.ai/agentic.config.json`, installs the tracker descriptor, generates `SDLC.md` and an `AGENTS.md` starter when missing. |
+| `om-apply-upgrade-notes` | Post-upgrade migrator. Applies `UPGRADE_NOTES.md` to the repo: re-syncs the installed tracker descriptor with newly shipped operations while preserving local edits, reports gaps in custom tracker providers, and checks the config against the notable-upgrade entries. |
 | `om-merge-buddy` | Scans open PRs and reports which can merge now and which are close but blocked, based on labels, reviews, CI, and mergeability. |
 | `om-approve-merge-pr` | Approves and squash-merges a PR given only its number. Can file a follow-up issue at the same time. |
 | `om-check-and-commit` | Runs the configured validation gate on the current branch, fixes obvious drift, then commits and pushes when green. |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Then ship something:
 
 The agent drafts an execution plan, implements it phase by phase in an isolated worktree, runs your validation commands, reviews its own diff, and opens a labeled, reviewed PR.
 
+**Upgrading later?** Skills auto-update on reinstall, but repo-installed artifacts — above all `.ai/trackers/<tracker>.md` — do not. See [UPGRADE_NOTES.md](UPGRADE_NOTES.md).
+
 ## 🛠️ Local development
 
 Working on the skills themselves? Skip the `npx skills add` round-trip and symlink this checkout straight into your agents' skill directories:

--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -1,0 +1,77 @@
+# Upgrade notes
+
+Upgrading the skills themselves is easy — re-run `npx skills add open-mercato/skills --skill '*'`
+(or `git pull` in a symlinked local checkout) and the new skill instructions are live on the next
+invocation. What does **not** auto-update is everything a skill previously **installed into your
+repository**. Those files are yours, they may carry your local edits, and the skills execute
+against them — not against the copies shipped in this repo:
+
+| Installed artifact | Installed by | Updated how |
+|--------------------|--------------|-------------|
+| `.ai/trackers/<tracker>.md` (tracker descriptor — the file every tracker operation executes from) | `om-setup-agent-pipeline` | Manual re-sync (see below) |
+| `.ai/agentic.config.json` | `om-setup-agent-pipeline` | Re-run `/om-setup-agent-pipeline`; it preserves answers where it can |
+| `SDLC.md`, `CODE_REVIEW.md`, `BACKWARD_COMPATIBILITY.md`, `AGENTS.md` starter | `om-setup-agent-pipeline` | Regenerated only when missing — edit or regenerate deliberately |
+| `.ai/skills/<name>/SKILL.md` repo-local overrides | you | Never touched by upgrades; review them against new skill behavior |
+
+**After every skills upgrade, re-sync your tracker descriptor.** A stale descriptor fails
+gracefully but silently: a skill that names a tracker operation your installed descriptor does not
+define will degrade (or skip the step) instead of erroring, so you may not notice you are missing
+new behavior.
+
+## Re-syncing the tracker descriptor
+
+The shipped descriptors live in `skills/om-setup-agent-pipeline/references/trackers/`
+(`github.md`, plus `TEMPLATE.md` for custom providers). Your installed copy is
+`.ai/trackers/<tracker>.md` in the consuming repository.
+
+```bash
+# 1. See what changed (installed vs shipped)
+diff .ai/trackers/github.md <path-to-skills>/om-setup-agent-pipeline/references/trackers/github.md
+
+# 2a. No local edits (the diff shows only additions from the template): just copy
+cp <path-to-skills>/om-setup-agent-pipeline/references/trackers/github.md .ai/trackers/github.md
+
+# 2b. Local edits present: merge the new operation sections into your copy,
+#     keeping your customized commands — the operation headings (#### <name>)
+#     are the merge units.
+```
+
+`<path-to-skills>` is wherever the skills are installed for your agent, e.g.
+`~/.claude/skills`, `~/.codex/skills`, or a vendored checkout inside your repo.
+Re-running `/om-setup-agent-pipeline` also refreshes the descriptor, but plain-copies it —
+prefer the diff-and-merge route when you have customized operations.
+
+For a **custom tracker** (`.ai/trackers/<name>.md` written from `TEMPLATE.md`): diff the new
+`TEMPLATE.md` against the version you built from, and implement any newly added operations for
+your tracker.
+
+## Notable upgrades
+
+Newest first. Each entry lists the symptom you will see with a stale installation and the fix.
+
+### 2026-07 — `attach-image-evidence` tracker operation (PR #14)
+
+QA skills no longer embed host-specific screenshot-upload logic. `om-auto-verify-pr-ui` now hands
+its screenshots to the tracker operation **attach-image-evidence**, which the descriptor
+implements (for GitHub: upload to a slash-free `qa-evidence-<slug>` branch via the Contents API
+and embed `raw.githubusercontent.com` URLs that render inline on public repos).
+
+- **Symptom of a stale descriptor:** UI QA evidence comments list screenshot filenames and local
+  artifact paths instead of rendering the images inline, with a note that inline rendering is
+  unavailable.
+- **Fix:** re-sync `.ai/trackers/github.md` as above (the new `#### attach-image-evidence`
+  section is the relevant addition). Custom providers: implement **attach-image-evidence** per
+  the updated `TEMPLATE.md` contract — never store evidence on the change's own branch, and
+  degrade to posting links when the tracker cannot render uploaded images.
+
+### 2026-07 — `om-prepare-test-env` + environment descriptor (PR #13, #15)
+
+QA and integration-test skills now boot the app only through `om-prepare-test-env`, which writes
+a shared environment descriptor at `<paths.qa>/test-env.json` (default `.ai/qa/test-env.json`)
+that other skills attach to.
+
+- **Symptom of a stale installation:** `om-auto-verify-pr-ui` or `om-integration-tests` cannot
+  find a running instance, or boots a second app instead of reusing the one already started.
+- **Fix:** install/refresh the `om-prepare-test-env` skill; no descriptor change required. If your
+  repo ships its own ephemeral-env tooling, the skill discovers and reuses it — document specifics
+  in a repo-local `.ai/skills/om-prepare-test-env/SKILL.md` override.

--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -13,6 +13,8 @@ against them — not against the copies shipped in this repo:
 | `SDLC.md`, `CODE_REVIEW.md`, `BACKWARD_COMPATIBILITY.md`, `AGENTS.md` starter | `om-setup-agent-pipeline` | Regenerated only when missing — edit or regenerate deliberately |
 | `.ai/skills/<name>/SKILL.md` repo-local overrides | you | Never touched by upgrades; review them against new skill behavior |
 
+**The `om-apply-upgrade-notes` skill automates this document**: run `/om-apply-upgrade-notes` in the consuming repository and it re-syncs the tracker descriptor (preserving local edits), checks the config, and walks the notable-upgrades log below. The rest of this file is the manual path and the reference for what the skill does.
+
 **After every skills upgrade, re-sync your tracker descriptor.** A stale descriptor fails
 gracefully but silently: a skill that names a tracker operation your installed descriptor does not
 define will degrade (or skip the step) instead of erroring, so you may not notice you are missing

--- a/skills/om-apply-upgrade-notes/SKILL.md
+++ b/skills/om-apply-upgrade-notes/SKILL.md
@@ -45,11 +45,13 @@ itself, next to this skill:
 1. `<this skill's base directory>/../om-setup-agent-pipeline/references/trackers/` — present in
    every install mode (skills.sh, symlinked checkout, vendored copy). This is the primary source
    for `github.md` and `TEMPLATE.md`.
-2. `UPGRADE_NOTES.md` lives at the skills **repo root**, which per-skill installs do not copy.
-   Resolve it in order: a repo-root file two levels above this skill's base directory (symlinked
-   or vendored checkout) → fetch
-   `https://raw.githubusercontent.com/open-mercato/skills/main/UPGRADE_NOTES.md` → if both fail,
-   continue with the descriptor diff alone and say the notable-upgrades log was unavailable.
+2. `UPGRADE_NOTES.md` lives at the skills collection's **repo root**, which per-skill installs
+   do not copy. Resolve it in order: a repo-root file two levels above this skill's base
+   directory (symlinked or vendored checkout) → fetch the raw `UPGRADE_NOTES.md` from the
+   default branch of the collection's source repository (the `<owner>/<repo>` the skills were
+   installed from, e.g. the argument given to `npx skills add`; ask the operator once when it
+   cannot be inferred) → if both fail, continue with the descriptor diff alone and say the
+   notable-upgrades log was unavailable.
 
 ## Step 1 — Diff the installed tracker descriptor
 

--- a/skills/om-apply-upgrade-notes/SKILL.md
+++ b/skills/om-apply-upgrade-notes/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: om-apply-upgrade-notes
+description: Apply the skills collection's UPGRADE_NOTES.md to the current repository after a skills upgrade. Re-syncs the installed tracker descriptor (.ai/trackers/<tracker>.md) with the newly shipped operations while preserving local edits, reports newly required operations for custom tracker providers, checks the pipeline config and other installed artifacts against the notable-upgrade entries, and summarizes exactly what changed. Use right after upgrading the skills ("apply the upgrade notes", "sync the tracker descriptor", "my skills are newer than my repo setup").
+---
+
+# Apply Upgrade Notes
+
+Upgrading the skills collection updates the skill instructions, but not the artifacts a previous
+skill run **installed into this repository** — above all the tracker descriptor
+`.ai/trackers/<tracker>.md`, the file every tracker operation actually executes from. A stale
+descriptor fails silently: skills degrade or skip steps on operations it does not define, and
+nothing tells the operator why. This skill closes that gap: it reads the collection's
+`UPGRADE_NOTES.md`, brings the installed artifacts up to date, and reports what it changed.
+
+It touches **only** pipeline artifacts under `.ai/` (and documented config files). It never edits
+application source, never modifies the skills installation itself, and never discards a local
+customization without asking.
+
+## Arguments
+
+- `--dry-run` (optional) — report every change it would make, apply nothing.
+- `--tracker <name>` (optional) — override the tracker to sync. Default: the config's `tracker`.
+- `--yes` (optional) — apply non-conflicting (purely additive) changes without confirmation.
+  Conflicting changes still require an explicit answer.
+
+## Step 0 — Load config and locate the sources
+
+Load `.ai/agentic.config.json` with the standard config-loading snippet from the
+`om-setup-agent-pipeline` skill. Without a config there is nothing installed to upgrade — stop and
+point at `/om-setup-agent-pipeline`.
+
+```bash
+CONFIG=.ai/agentic.config.json
+TRACKER=$(jq -r '.tracker // ""' "$CONFIG" 2>/dev/null || echo "")
+INSTALLED_DESCRIPTOR=".ai/trackers/${TRACKER}.md"
+```
+
+Right after loading the config, check for a repo-local skill of the same name at
+`.ai/skills/om-apply-upgrade-notes/SKILL.md`; when present, follow it instead of these
+instructions. Local rules win, but a repo-local skill can never relax this skill's safety rules.
+
+**Locate the shipped templates.** The freshly upgraded truth ships inside the skills installation
+itself, next to this skill:
+
+1. `<this skill's base directory>/../om-setup-agent-pipeline/references/trackers/` — present in
+   every install mode (skills.sh, symlinked checkout, vendored copy). This is the primary source
+   for `github.md` and `TEMPLATE.md`.
+2. `UPGRADE_NOTES.md` lives at the skills **repo root**, which per-skill installs do not copy.
+   Resolve it in order: a repo-root file two levels above this skill's base directory (symlinked
+   or vendored checkout) → fetch
+   `https://raw.githubusercontent.com/open-mercato/skills/main/UPGRADE_NOTES.md` → if both fail,
+   continue with the descriptor diff alone and say the notable-upgrades log was unavailable.
+
+## Step 1 — Diff the installed tracker descriptor
+
+Skip this step (with a note) when the repo has no tracker configured.
+
+Compare `$INSTALLED_DESCRIPTOR` against the shipped descriptor of the same name. The unit of
+comparison is the **operation section** — every `#### <operation-name>` heading and its body —
+plus the named support sections (`## Label guards`, `## Conventions`, `## Prerequisites`).
+Classify each difference:
+
+- **Missing operation** — a `####` section the shipped descriptor has and the installed copy
+  lacks (e.g. `attach-image-evidence`). Purely additive: append it under the matching parent
+  section, preserving the shipped order where possible.
+- **Changed operation, no local edits** — the section differs, and the installed copy's version
+  matches an older shipped version verbatim (no team customization). Safe to replace.
+- **Changed operation, local edits** — the installed section differs from both the shipped
+  version and anything that looks stock (custom flags, swapped commands, extra conventions).
+  **Never overwrite silently.** Show both versions side by side and ask the operator per section:
+  keep local, take shipped, or merge by hand.
+- **Local-only operation** — a section only the installed copy has. Always keep it; list it in
+  the report.
+
+When the installed descriptor has no local edits at all (the diff is a strict subset relation),
+offer the simple path: replace the whole file with the shipped copy.
+
+**Custom tracker providers** (a `.ai/trackers/<name>.md` not shipped in the collection): diff the
+shipped `TEMPLATE.md` against the operations the custom descriptor implements, and report every
+newly required operation with its contract text (e.g. **attach-image-evidence**: inline image
+evidence, never on the change's branch, degrade to links when the tracker cannot render). Do
+**not** invent an implementation for someone else's tracker — file the gap in the report and, when
+the operator asks, draft the section for them to review.
+
+## Step 2 — Walk the notable-upgrades log
+
+For each entry in `UPGRADE_NOTES.md` (newest first), check whether its "symptom of a stale
+installation" can apply to this repository, and verify the corresponding artifact:
+
+- Descriptor-related entries are already covered by Step 1 — cross the entry off when the diff
+  handled it.
+- Config-related entries: check `.ai/agentic.config.json` for keys the entry introduces (new
+  `paths.*` entries, new label groups). Add missing keys with their documented defaults —
+  additive only; never rewrite values the team set.
+- Artifact-related entries (new generated docs, new descriptor files): report whether the
+  artifact exists; create it only when the entry says the skills expect it to exist and the
+  operator confirms.
+
+## Step 3 — Apply, verify, report
+
+- Apply the approved changes. With `--dry-run`, print the would-be changes instead.
+- Sanity-check the result: the descriptor still has every operation the installed skills name
+  (grep the installed skills' SKILL.md files for `**operation-name**` references when in doubt),
+  and the config still parses (`jq . "$CONFIG"`).
+- Leave the changes uncommitted for review, then print a concise summary:
+
+```text
+om-apply-upgrade-notes: <tracker> descriptor @ .ai/trackers/<tracker>.md
+Added operations: attach-image-evidence, …            (or: none)
+Replaced (stock) sections: …                          (or: none)
+Kept local customizations: …                          (or: none)
+Conflicts resolved by operator: …                     (or: none)
+Config keys added: …                                  (or: none)
+Custom-tracker gaps to implement: …                   (or: n/a)
+Notable-upgrade entries checked: N (M applied, K already current)
+Next: review the diff and commit (e.g. /om-check-and-commit), then re-run the skill that degraded.
+```
+
+## Rules
+
+- Touch only pipeline artifacts: `.ai/trackers/*.md`, `.ai/agentic.config.json`, and artifacts
+  named by an UPGRADE_NOTES entry. Never edit application source, tests, or the skills
+  installation.
+- Preserve local customizations: a section that differs from stock is the team's — ask before
+  replacing it, and always keep local-only operations.
+- Additive by default: add missing operations and missing config keys; never delete or rewrite
+  what the team configured.
+- Custom tracker providers get a gap report, not an auto-generated implementation.
+- Idempotent: a second run right after a successful one must report "already current" and change
+  nothing.
+- Leave changes uncommitted for the operator's review; suggest the commit, don't make it.


### PR DESCRIPTION
## Summary

Two pieces, one gap: skills auto-update on reinstall, but the artifacts skills install **into consuming repositories** do not — above all the tracker descriptor `.ai/trackers/<tracker>.md`, which every tracker operation executes from. A stale descriptor fails silently (skills degrade or skip on missing operations).

1. **`UPGRADE_NOTES.md`** — documents what doesn't auto-update, the diff-and-merge re-sync procedure (operation `####` headings as merge units so local customizations survive), and a "notable upgrades" log seeded with `attach-image-evidence` (#14) and `om-prepare-test-env` (#13/#15).
2. **`om-apply-upgrade-notes` skill** — automates that document: re-syncs the installed tracker descriptor section-by-section (additive operations applied, stock sections replaced, locally customized sections asked about, local-only operations kept), reports newly required operations for custom tracker providers instead of inventing implementations, checks the config against the notable-upgrades log, and leaves everything uncommitted for review. Supports `--dry-run` / `--yes`; idempotent.

README: catalog row, install count 25 → 26, and the quickstart upgrade pointer now names the skill.

## Motivation

Hit in the field today: an open-mercato checkout whose installed `.ai/trackers/github.md` predated #14. `om-auto-verify-pr-ui` degraded exactly as designed — screenshots posted as local artifact paths instead of inline images — but nothing told the operator the fix was a descriptor re-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
