### PR TITLE
docs(readme): add YouTube video link above Local development section

### DIFF
--- a/.ai/runs/2026-07-13-readme-youtube-video.md
+++ b/.ai/runs/2026-07-13-readme-youtube-video.md
@@ -49,4 +49,4 @@ Add the provided YouTube video thumbnail link to the main `README.md`, placed di
 
 ### Phase 2: Validation
 
-- [ ] 2.1 Run validation gate and re-read diff
+- [x] 2.1 Run validation gate and re-read diff — 57ad0c7 (lint OK, no code changes needed)

--- a/.ai/runs/2026-07-13-readme-youtube-video.md
+++ b/.ai/runs/2026-07-13-readme-youtube-video.md
@@ -45,7 +45,7 @@ Add the provided YouTube video thumbnail link to the main `README.md`, placed di
 
 ### Phase 1: README update
 
-- [ ] 1.1 Insert YouTube thumbnail link above Local development section
+- [x] 1.1 Insert YouTube thumbnail link above Local development section — 57ad0c7
 
 ### Phase 2: Validation
 

--- a/.ai/runs/2026-07-13-readme-youtube-video.md
+++ b/.ai/runs/2026-07-13-readme-youtube-video.md
@@ -1,0 +1,52 @@
+# Execution plan: add YouTube video to main README
+
+- Date: 2026-07-13
+- Slug: readme-youtube-video
+- Branch: feat/readme-youtube-video
+- Owner: pkarw
+
+## Overview
+
+### Goal
+
+Add the provided YouTube video thumbnail link to the main `README.md`, placed directly above the `## 🛠️ Local development` section.
+
+### Scope
+
+- `README.md` only — insert the markdown snippet supplied in the brief:
+  `[![Watch on YouTube](https://img.youtube.com/vi/zPNW-xtwNsE/maxresdefault.jpg)](https://www.youtube.com/watch?v=zPNW-xtwNsE)`
+
+### Non-goals
+
+- No other README restructuring or copy edits.
+- No changes to skills, scripts, or docs beyond the README.
+
+### External References
+
+- None (`--skill-url` not provided).
+
+## Implementation Plan
+
+### Phase 1: README update
+
+- 1.1 Insert the YouTube thumbnail link into `README.md` above the `## 🛠️ Local development` heading.
+
+### Phase 2: Validation
+
+- 2.1 Run the validation gate (`bash scripts/lint.sh`) and re-read the diff.
+
+## Risks
+
+- Docs-only change; the main risk is markdown rendering placement. Mitigated by re-reading the rendered diff. The thumbnail URL (`maxresdefault.jpg`) is served by YouTube for the given video id; if the video were removed the image would 404, which is acceptable for a README link.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: README update
+
+- [ ] 1.1 Insert YouTube thumbnail link above Local development section
+
+### Phase 2: Validation
+
+- [ ] 2.1 Run validation gate and re-read diff

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ The agent drafts an execution plan, implements it phase by phase in an isolated 
 
 **Upgrading later?** Skills auto-update on reinstall, but repo-installed artifacts — above all `.ai/trackers/<tracker>.md` — do not. Run `/om-apply-upgrade-notes` in the repo, or follow [UPGRADE_NOTES.md](UPGRADE_NOTES.md) by hand.
 
+[![Watch on YouTube](https://img.youtube.com/vi/zPNW-xtwNsE/maxresdefault.jpg)](https://www.youtube.com/watch?v=zPNW-xtwNsE)
+
 ## 🛠️ Local development
 
 Working on the skills themselves? Skip the `npx skills add` round-trip and symlink this checkout straight into your agents' skill directories:


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-13-readme-youtube-video.md
Status: complete

## Goal
- Add the YouTube video thumbnail link to the main README, directly above the "Local development" section.

## What Changed
- Inserted `[![Watch on YouTube](https://img.youtube.com/vi/zPNW-xtwNsE/maxresdefault.jpg)](https://www.youtube.com/watch?v=zPNW-xtwNsE)` into `README.md` between the "Upgrading later?" paragraph and the `## 🛠️ Local development` heading.
- Added the execution plan at `.ai/runs/2026-07-13-readme-youtube-video.md`.

## Tests
- Docs-only change; no unit tests apply.
- Validation gate: `bash scripts/lint.sh` — passed (`Lint OK.`).
- Manual re-read of the diff confirmed the insertion point and markdown syntax.

## Breaking Changes
- None (README-only).

## Progress
See the Progress section in the tracking plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
