### PR TITLE
feat(browser): add agent-browser provider support

### DIFF
--- a/.ai/analysis/2026-07-14-agent-browser-verification.md
+++ b/.ai/analysis/2026-07-14-agent-browser-verification.md
@@ -1,0 +1,94 @@
+# Agent-browser verification report
+
+Date: 2026-07-14
+
+## Contract and platform matrix
+
+Command: `node scripts/test-browser-providers.mjs`
+
+Result: PASS — both shipped descriptors implement all eight browser operations.
+The release-selector matrix covered:
+
+- macOS: x64 and arm64
+- Linux glibc: x64 and arm64
+- Linux musl: x64 and arm64
+- WSL2: x64 and arm64 through the Linux assets
+- Native Windows: x64 and ARM64 through the supported x64 compatibility path
+
+The contract test also confirms the agent-browser provider contains POSIX and
+native PowerShell download paths, autonomous Chrome installation, Linux
+non-interactive dependency escalation, a live `doctor --json` launch gate, and
+no cloud-provider credential path.
+
+This is deterministic selection/contract coverage. The current host is Linux
+x64; native macOS, Windows, musl, ARM64, and WSL2 execution was not available in
+this run and is not represented as observed execution.
+
+## Codex CLI end-to-end exercise
+
+Harness: `KEEP_CODEX_E2E_FIXTURE=1 bash scripts/test-agent-browser-codex.sh`
+
+Codex CLI: 0.144.4, invoked with repo-scoped skills through `codex exec
+--ephemeral --sandbox danger-full-access --ignore-user-config` in an isolated
+fixture repository.
+
+### `om-prepare-test-env`
+
+Result: PASS after one self-repair cycle.
+
+- Downloaded the official `agent-browser` 0.31.2 Linux x64 native release into
+  the per-user cache; no project package or Node-based browser dependency was
+  installed.
+- Downloaded Chrome for Testing 150.0.7871.115 through `agent-browser install`.
+- `agent-browser doctor --json`: success, 9 pass / 0 warn / 0 fail, including a
+  real headless launch in 0.40s.
+- Generated portable environment scripts and a provider-neutral
+  `.ai/qa/test-env.json` reporting `browser.provider=agent-browser` and
+  `browser.installed=true`.
+- Cold app boot: 0.81s. Initial warm boot exposed a reuse bug in the generated
+  fixture entrypoint; the skill repaired it and proved a 0.12s warm reuse with
+  the same run id and PID.
+- Source-fingerprint invalidation passed and a subsequent warm run reused the
+  rebuilt environment.
+
+### `om-auto-verify-pr-ui`
+
+Result: PASS.
+
+- Reused the prepared environment and opened the local fixture through the
+  configured agent-browser binary.
+- Observed accessibility refs for heading `Agent Browser Fixture Updated` and
+  button `Continue`; asserted text and visibility through provider operations.
+- Captured desktop (1280x577, 11,928 bytes) and mobile (390x844, 11,722 bytes)
+  PNG evidence.
+- Wrote PASS `report.json` and `report.md` with
+  `environment.browserProvider=agent-browser`.
+- The live run exposed ambiguous relative screenshot-path handling in the CLI;
+  the shipped descriptor now resolves an absolute output path before capture.
+- Verified the source HTML checksum was unchanged during the read-only QA run.
+
+### `om-integration-tests`
+
+Result: PASS on the POSIX launcher; native PowerShell execution unavailable.
+
+- Explored the live page through agent-browser before authoring assertions.
+- Generated paired `tests/browser/fixture-title.sh` and
+  `tests/browser/fixture-title.ps1` launchers with equivalent semantic
+  role/name assertions and isolated-session cleanup.
+- POSIX launcher executed successfully: `PASS fixture title and button
+  regression`.
+- The first Codex pass generated a PowerShell launcher that called `sh`; the
+  skill contract was tightened and the Codex phase rerun. The replacement `.ps1`
+  contains no `sh`, WSL, Git Bash, Node, or POSIX utility calls and selects the
+  native `.ai/scripts/test-env-up.ps1` entrypoint when available.
+- `pwsh` was unavailable on this Linux host, so the PowerShell launcher was
+  inspected and dependency-scanned but not natively executed.
+
+## Verification boundary
+
+Observed end-to-end execution proves the Linux x64 path and confirms Codex
+actually followed all three skills. Cross-platform guarantees are supported by
+the official agent-browser native release matrix, separate POSIX/PowerShell
+descriptor operations, platform-native generated-test requirements, and the
+deterministic matrix test. Native execution on every OS/CPU remains appropriate
+follow-up CI coverage when runners for those targets are available.

--- a/.ai/runs/2026-07-14-agent-browser-support.md
+++ b/.ai/runs/2026-07-14-agent-browser-support.md
@@ -61,8 +61,8 @@ Add first-class, configurable agent-browser support to the agent pipeline so bro
 
 ### Phase 2: Browser consumers
 
-- [ ] 2.1 Update environment provisioning and descriptor compatibility
-- [ ] 2.2 Update UI verification and integration-test provider execution
+- [x] 2.1 Update environment provisioning and descriptor compatibility — b0b9c84
+- [x] 2.2 Update UI verification and integration-test provider execution — 0b2a037
 
 ### Phase 3: Verification harness
 

--- a/.ai/runs/2026-07-14-agent-browser-support.md
+++ b/.ai/runs/2026-07-14-agent-browser-support.md
@@ -68,3 +68,4 @@ Add first-class, configurable agent-browser support to the agent pipeline so bro
 
 - [x] 3.1 Add contract and cross-platform bootstrap tests — eff14d8
 - [x] 3.2 Run Codex CLI skill exercises and record evidence — 857bd0b
+- [x] Post-review fix: validate provider paths, align descriptor examples, bound downloads, and tear down the Codex fixture — 6929a9a

--- a/.ai/runs/2026-07-14-agent-browser-support.md
+++ b/.ai/runs/2026-07-14-agent-browser-support.md
@@ -52,6 +52,8 @@ Add first-class, configurable agent-browser support to the agent pipeline so bro
 
 ## Progress
 
+PR: #23
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Provider contract and setup

--- a/.ai/runs/2026-07-14-agent-browser-support.md
+++ b/.ai/runs/2026-07-14-agent-browser-support.md
@@ -1,0 +1,70 @@
+# Agent-browser provider support
+
+## Overview
+
+### Goal
+
+Add first-class, configurable agent-browser support to the agent pipeline so browser-capable skills can provision and use it without requiring the operator to preinstall runtimes, browser binaries, or OS packages.
+
+### Scope
+
+- Add a browser-provider selection and descriptor contract to `om-setup-agent-pipeline`, parallel to tracker providers.
+- Ship agent-browser and Playwright provider descriptors with autonomous provisioning guidance for macOS, Linux, WSL2, Git Bash, and native Windows.
+- Update the shared test-environment descriptor and every browser consumer to select the configured provider while remaining compatible with existing Playwright-only repositories.
+- Extend `om-apply-upgrade-notes`, `UPGRADE_NOTES.md`, and collection documentation for installed-artifact upgrades.
+- Add deterministic contract/platform tests and Codex CLI end-to-end exercises that invoke the affected skills against a local fixture.
+
+### Non-goals
+
+- Do not change tracker-provider semantics or label behavior.
+- Do not add a runtime dependency to this markdown-first repository.
+- Do not require cloud browser services, API keys, or remote third-party browser infrastructure.
+- Do not claim native execution on platforms unavailable to the current CI host; validate those paths with deterministic platform-selection/bootstrap tests and document the boundary.
+
+### External References
+
+- `https://github.com/vercel-labs/agent-browser` — adopted the official native release matrix, local Chrome-for-Testing installation, `doctor`, snapshot/ref interaction model, and Linux `--with-deps` flow; rejected cloud providers because this feature must be self-contained.
+- OpenAI Codex manual, non-interactive mode and skill discovery — adopted repo-scoped skills plus `codex exec --ephemeral` for isolated end-to-end exercises.
+
+## Implementation Plan
+
+### Phase 1: Provider contract and setup
+
+1. Add the additive browser config, loading contract, provider template, and shipped agent-browser/Playwright descriptors.
+2. Teach setup and upgrade flows to install or reconcile browser descriptors, and document the upgrade path.
+
+### Phase 2: Browser consumers
+
+1. Update test-environment provisioning and descriptor output to use the selected browser provider with legacy Playwright fallback.
+2. Update UI verification and integration-test skills to execute provider operations and preserve existing repository-native runners.
+
+### Phase 3: Verification harness
+
+1. Add static and platform-matrix tests for provider completeness, fallback behavior, and autonomous installation commands.
+2. Run Codex CLI skill exercises against a local fixture and record an evidence-backed cross-platform verification report.
+
+## Risks
+
+- agent-browser release assets currently cover macOS x64/arm64, Linux x64/arm64 (glibc and musl), and Windows x64; unsupported CPU/OS combinations must fail explicitly rather than silently selecting the wrong binary.
+- Linux browser libraries can require privileged package installation. The agent must attempt the provider's self-install flow itself and report a concrete privilege blocker only after exhausting existing-browser and non-interactive elevation paths.
+- Existing consumer repositories may have a Playwright-shaped version-1 `test-env.json`; readers must accept that shape while new writers add a provider-neutral field.
+- Repository-native E2E suites remain authoritative. Selecting agent-browser changes agent-driven exploration and evidence capture, not a project's chosen committed test framework unless no suite exists.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Provider contract and setup
+
+- [ ] 1.1 Add browser config, loading contract, template, and shipped descriptors
+- [ ] 1.2 Update setup, upgrade flow, and upgrade documentation
+
+### Phase 2: Browser consumers
+
+- [ ] 2.1 Update environment provisioning and descriptor compatibility
+- [ ] 2.2 Update UI verification and integration-test provider execution
+
+### Phase 3: Verification harness
+
+- [ ] 3.1 Add contract and cross-platform bootstrap tests
+- [ ] 3.2 Run Codex CLI skill exercises and record evidence

--- a/.ai/runs/2026-07-14-agent-browser-support.md
+++ b/.ai/runs/2026-07-14-agent-browser-support.md
@@ -56,8 +56,8 @@ Add first-class, configurable agent-browser support to the agent pipeline so bro
 
 ### Phase 1: Provider contract and setup
 
-- [ ] 1.1 Add browser config, loading contract, template, and shipped descriptors
-- [ ] 1.2 Update setup, upgrade flow, and upgrade documentation
+- [x] 1.1 Add browser config, loading contract, template, and shipped descriptors — fcbe802
+- [x] 1.2 Update setup, upgrade flow, and upgrade documentation — b935408
 
 ### Phase 2: Browser consumers
 

--- a/.ai/runs/2026-07-14-agent-browser-support.md
+++ b/.ai/runs/2026-07-14-agent-browser-support.md
@@ -66,5 +66,5 @@ Add first-class, configurable agent-browser support to the agent pipeline so bro
 
 ### Phase 3: Verification harness
 
-- [ ] 3.1 Add contract and cross-platform bootstrap tests
-- [ ] 3.2 Run Codex CLI skill exercises and record evidence
+- [x] 3.1 Add contract and cross-platform bootstrap tests — eff14d8
+- [x] 3.2 Run Codex CLI skill exercises and record evidence — 857bd0b

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,3 +12,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Frontmatter and product-agnosticism gate
         run: bash scripts/lint.sh
+      - name: Browser provider contract and platform matrix
+        run: node scripts/test-browser-providers.mjs

--- a/BACKWARD_COMPATIBILITY.md
+++ b/BACKWARD_COMPATIBILITY.md
@@ -26,7 +26,20 @@ The named operations (**get-issue**, **create-pr**, **comment-pr**, **merge-pr**
 - **Breaking:** renaming an operation, changing an operation's inputs/outputs, removing a guard, referencing a new operation from a skill without adding it to the template and shipped descriptors.
 - **Required path:** add new operations to `TEMPLATE.md` and every shipped descriptor in the same PR; skills must degrade gracefully (documented fallback) when running against an older descriptor copy that lacks a newly added operation.
 
-### 4. Cross-skill file formats
+### 4. The browser-provider operations contract
+
+The named browser operations (**ensure-installed**, **doctor**, **open**,
+**snapshot**, **interact**, **assert**, **screenshot**, **close**) defined by
+`skills/om-setup-agent-pipeline/references/browsers/TEMPLATE.md`. Consumer repos
+hold committed, possibly team-edited copies at `.ai/browsers/<provider>.md`.
+
+- **Breaking:** renaming an operation, changing its inputs/outputs, or selecting
+  a provider without installing its descriptor.
+- **Required path:** update `TEMPLATE.md` and every shipped browser descriptor in
+  the same PR. Browser consumers must retain the implicit Playwright fallback
+  for configs and environment descriptors created before this contract existed.
+
+### 5. Cross-skill file formats
 
 - **Execution-plan `## Progress` section** (`- [ ]` / `- [x]` checklists with `N.M` step ids and ` — <sha>` suffixes) — written by `om-auto-create-pr`, parsed by `om-auto-continue-pr`.
 - **PR body `Tracking plan:` and `Status:` lines** — written by `om-auto-create-pr`, parsed by `om-auto-continue-pr` and the loop skills.
@@ -35,14 +48,17 @@ The named operations (**get-issue**, **create-pr**, **comment-pr**, **merge-pr**
 
 **Breaking:** changing any of these formats so an unmodified consumer skill can no longer parse output produced by a modified producer (or vice versa). **Required path:** update producer and all consumers in one PR, and keep the parser tolerant of the previous format when consumer repos may hold old artifacts (committed plans, descriptors).
 
-### 5. The label taxonomy semantics
+Adding the provider-neutral `browser` object to `test-env.json` is additive;
+readers must continue accepting the legacy `playwright` object.
+
+### 6. The label taxonomy semantics
 
 The pipeline/category/meta/priority/risk groups, their exclusivity rules, and the QA-gate meaning of `needs-qa`/`qa-approved`/`skip-qa`. Consumer repos have these labels created in their trackers and encoded in their committed `SDLC.md`.
 
 - **Breaking:** renaming a label, changing a group's exclusivity, weakening the QA gate rule.
 - **Required path:** additive labels only; renames need a documented migration note and support for both names in the skills for one release cycle.
 
-### 6. Installer CLI (`package.json` scripts, `scripts/install-skills.mjs`)
+### 7. Installer CLI (`package.json` scripts, `scripts/install-skills.mjs`)
 
 `npm run install-skills` / `uninstall-skills` flags and behavior, and the skills.sh-compatible repo layout it relies on.
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -40,6 +40,19 @@ An earlier revision (see Deferred) removed the upstream ephemeral-environment ma
 
 No skill calls a tracker CLI or API directly. Skills name **tracker operations** (**get-issue**, **create-pr**, **comment-pr**, **merge-pr**, …) and a single committed descriptor file, `.ai/trackers/<tracker>.md` — selected by the config's `tracker` field and installed by `om-setup-agent-pipeline` — defines how each operation executes. The collection ships the GitHub descriptor (`gh` CLI) plus a `TEMPLATE.md` documenting the full contract; a new provider (Linear, Jira, …) is one descriptor file, no skill changes. The descriptor is a markdown instruction layer rather than code on purpose: it is read by the agent at runtime, so it works identically across coding agents, and the repo's committed copy is the override point — teams edit it to extend or replace any operation, the same "local file wins" model as repo-local skills. Split setups (issues in Linear, PRs on GitHub) implement issue operations against the issue tracker and delegate the PR sections to the GitHub descriptor. An earlier design kept `gh` calls inline in the skills and deferred extraction until a second provider existed; the extraction was pulled forward because inline calls made every skill GitHub-shaped and blocked the drop-in/override story. CI now enforces the layer: the lint gate rejects `gh` commands inside `skills/**` outside the shipped tracker descriptors.
 
+## Browser-provider abstraction
+
+Browser automation uses the same committed markdown-descriptor pattern as
+trackers, under `.ai/browsers/<provider>.md` and selected by
+`browser.provider`. The shared operation contract separates agent-driven
+exploration, assertions, screenshots, and autonomous tool provisioning from the
+skills that consume them. Fresh setups select agent-browser; Playwright remains
+shipped as a compatibility provider, and absent config keys/legacy
+`test-env.json` files continue to mean Playwright. Repository-native E2E suites
+stay authoritative regardless of the exploration provider. This boundary avoids
+hard-wiring every QA skill to a single CLI while keeping the repo's committed
+descriptor as the customization point.
+
 ## Deferred
 
 - A bespoke `npx open-mercato-skills` installer CLI. skills.sh covers installation in v1.

--- a/README.md
+++ b/README.md
@@ -220,6 +220,21 @@ That file is yours, which makes three things easy:
 
 The claim protocol (assignee + `in-progress` + 🤖 comment), the label guards (missing label ⇒ logged skip, `labels.enabled: false` ⇒ no label ops), and the QA gate semantics are part of the contract — a provider must express them, in whatever way its tracker allows.
 
+### Browser automation providers
+
+QA and integration-test skills select `browser.provider` from
+`.ai/agentic.config.json` and execute the committed descriptor at
+`.ai/browsers/<provider>.md`. Fresh setups use agent-browser; Playwright remains
+available for existing repositories and teams that prefer it. The agent-browser
+descriptor downloads its native release binary and Chrome for Testing itself,
+then verifies a live headless launch — no Node runtime, project dependency, or
+cloud-browser subscription is required.
+
+Custom providers implement the operations in
+`skills/om-setup-agent-pipeline/references/browsers/TEMPLATE.md`. Repository E2E
+suites remain authoritative; the provider controls agent-driven exploration,
+assertions, and screenshots.
+
 ## 🏷️ Labels and the QA gate
 
 Every PR carries at most one pipeline label (`review`, `changes-requested`, `merge-queue`, ...) plus additive category, meta, priority, and risk labels; priority says how urgent the work is, risk says how dangerous the change is to ship. The full taxonomy, and whether to use labels at all, lives in the config; `om-setup-agent-pipeline` documents every group and creates missing labels for you.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Then ship something:
 
 The agent drafts an execution plan, implements it phase by phase in an isolated worktree, runs your validation commands, reviews its own diff, and opens a labeled, reviewed PR.
 
-**Upgrading later?** Skills auto-update on reinstall, but repo-installed artifacts — above all `.ai/trackers/<tracker>.md` — do not. Run `/om-apply-upgrade-notes` in the repo, or follow [UPGRADE_NOTES.md](UPGRADE_NOTES.md) by hand.
+**Upgrading later?** Skills auto-update on reinstall, but repo-installed artifacts — including `.ai/trackers/<tracker>.md` and `.ai/browsers/<provider>.md` — do not. Run `/om-apply-upgrade-notes` in the repo, or follow [UPGRADE_NOTES.md](UPGRADE_NOTES.md) by hand.
 
 ## 🎬 See how it works!
 
@@ -117,8 +117,8 @@ Interactive helpers: they act once, report, and hand control back to you.
 
 | Skill | What it does |
 |---|---|
-| `om-setup-agent-pipeline` | One-per-repo configurator. Inspects the repository, asks a few questions, writes `.ai/agentic.config.json`, installs the tracker descriptor, generates `SDLC.md` and an `AGENTS.md` starter when missing. |
-| `om-apply-upgrade-notes` | Post-upgrade migrator. Applies `UPGRADE_NOTES.md` to the repo: re-syncs the installed tracker descriptor with newly shipped operations while preserving local edits, reports gaps in custom tracker providers, and checks the config against the notable-upgrade entries. |
+| `om-setup-agent-pipeline` | One-per-repo configurator. Inspects the repository, asks a few questions, writes `.ai/agentic.config.json`, installs tracker and browser-provider descriptors, generates `SDLC.md` and an `AGENTS.md` starter when missing. |
+| `om-apply-upgrade-notes` | Post-upgrade migrator. Applies `UPGRADE_NOTES.md` to the repo: re-syncs installed tracker/browser descriptors while preserving local edits, reports custom-provider gaps, and checks the config against notable upgrades. |
 | `om-merge-buddy` | Scans open PRs and reports which can merge now and which are close but blocked, based on labels, reviews, CI, and mergeability. |
 | `om-approve-merge-pr` | Approves and squash-merges a PR given only its number. Can file a follow-up issue at the same time. |
 | `om-check-and-commit` | Runs the configured validation gate on the current branch, fixes obvious drift, then commits and pushes when green. |
@@ -126,7 +126,7 @@ Interactive helpers: they act once, report, and hand control back to you.
 | `om-spec-writing` | Writes and reviews feature specs to staff-engineer standards: skeleton-first with a hard Open Questions gate, phased implementation breakdown that feeds `om-auto-create-pr`, severity-ranked architectural reviews. |
 | `om-prepare-issue` | Files a well-formed tracker issue for deferred work: dedupes against existing issues and PRs first, links the covering spec when one exists, otherwise embeds a step-by-step implementation analysis derived from the codebase. |
 | `om-integration-tests` | Creates and runs integration/E2E tests by exploring the running app first — real locators, runtime fixtures, no hardcoded IDs — and reports failures with artifact-based per-test diagnosis. Reuses the shared `om-prepare-test-env` instance so QA and tests hit the same booted app. |
-| `om-auto-verify-pr-ui` | Runs the app locally and QAs a change's UI in a real browser without merging: boots via `om-prepare-test-env`, derives a scenario from the diff, drives Playwright with screenshots, and produces a pass/fail report. Posts the evidence as a PR comment when a tracker is configured; otherwise saves screenshots + a JSON/Markdown report to an artifacts folder. |
+| `om-auto-verify-pr-ui` | Runs the app locally and QAs a change's UI in a real browser without merging: boots via `om-prepare-test-env`, derives a scenario from the diff, drives the configured browser provider with screenshots, and produces a pass/fail report. Posts evidence as a PR comment when a tracker is configured; otherwise saves screenshots + JSON/Markdown reports. |
 | `om-auto-update-changelog` | Drafts a CHANGELOG.md release entry for every PR merged since the last release — emoji categories, contributor credits with the Supersede Credit Rule for carried-forward fork PRs — then delegates to `om-auto-create-pr` to ship it as a docs PR. |
 
 ### 🤝 Skills invoke each other
@@ -140,7 +140,7 @@ The building blocks behind the autofix chain and the review loop. You can call t
 | `om-fix` | Implements the minimal change, adds regression tests, runs the validation gate. Does not commit or push. |
 | `om-open-pr` | Commits the worktree, pushes the branch, opens the PR, normalizes labels, releases the claim lock. |
 | `om-code-review` | The review checklist behind `om-auto-review-pr`: correctness, security, contract surfaces, plus your repo-local checklist when configured. |
-| `om-prepare-test-env` | Boots the app for QA and tests, any stack: reuses the repo's own ephemeral/test environment when it has one, generates Docker/testcontainers-style bring-up scripts for the project's backing services (Postgres, MySQL, Mongo, …) when a disposable environment is wanted and none exists, or runs the app in dev/docker/production mode otherwise. Keeps bootstrap fast: reuses running environments (PID-checked, health-probed, freshness-validated), caches builds behind source/env fingerprints, locks concurrent bootstraps, and records every bootstrap lesson so the next boot cannot repeat it. Installs Playwright when missing and writes a shared environment descriptor so QA and tests reuse one instance. Works on macOS, Linux, WSL2, and Windows. |
+| `om-prepare-test-env` | Boots the app for QA and tests, any stack: reuses the repo's own environment or generates portable bring-up scripts, then caches builds and validates warm reuse. It autonomously provisions the configured browser provider (agent-browser by default; Playwright supported), writes a shared environment descriptor, and works on macOS, Linux, WSL2, and Windows. |
 
 ## 🧰 Works with any stack
 
@@ -151,6 +151,7 @@ Nothing here assumes JavaScript, or any particular product. The base branch, the
   "version": 1,
   "baseBranch": "auto",
   "tracker": "github",
+  "browser": { "provider": "agent-browser" },
   "validation": {
     "commands": ["pnpm typecheck", "pnpm test", "pnpm build"]
   },
@@ -177,6 +178,10 @@ Nothing here assumes JavaScript, or any particular product. The base branch, the
 A Rust repo puts `cargo test` and `cargo clippy` in `validation.commands`; a Go repo puts `go test ./...`. Skills run whatever you configure and treat any non-zero exit as a gate failure. A skill invoked in a repo without the config runs `om-setup-agent-pipeline` first — interactively when you're there to answer its questions, with `--defaults` when running unattended — then continues with the freshly written config.
 
 GitHub is the default tracker, but nothing in the skills is hard-wired to it — see the tracker providers section below.
+
+Agent-browser is the default browser automation provider for fresh setups. It
+installs itself and Chrome for Testing when needed; existing repositories remain
+on Playwright until their config makes a provider explicit.
 
 ## 🎨 Make it yours
 

--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -9,13 +9,14 @@ against them — not against the copies shipped in this repo:
 | Installed artifact | Installed by | Updated how |
 |--------------------|--------------|-------------|
 | `.ai/trackers/<tracker>.md` (tracker descriptor — the file every tracker operation executes from) | `om-setup-agent-pipeline` | Manual re-sync (see below) |
+| `.ai/browsers/<provider>.md` (browser automation and autonomous provisioning operations) | `om-setup-agent-pipeline` | Manual re-sync (see below) |
 | `.ai/agentic.config.json` | `om-setup-agent-pipeline` | Re-run `/om-setup-agent-pipeline`; it preserves answers where it can |
 | `SDLC.md`, `CODE_REVIEW.md`, `BACKWARD_COMPATIBILITY.md`, `AGENTS.md` starter | `om-setup-agent-pipeline` | Regenerated only when missing — edit or regenerate deliberately |
 | `.ai/skills/<name>/SKILL.md` repo-local overrides | you | Never touched by upgrades; review them against new skill behavior |
 
 **The `om-apply-upgrade-notes` skill automates this document**: run `/om-apply-upgrade-notes` in the consuming repository and it re-syncs the tracker descriptor (preserving local edits), checks the config, and walks the notable-upgrades log below. The rest of this file is the manual path and the reference for what the skill does.
 
-**After every skills upgrade, re-sync your tracker descriptor.** A stale descriptor fails
+**After every skills upgrade, re-sync your tracker and browser descriptors.** A stale descriptor fails
 gracefully but silently: a skill that names a tracker operation your installed descriptor does not
 define will degrade (or skip the step) instead of erroring, so you may not notice you are missing
 new behavior.
@@ -47,9 +48,36 @@ For a **custom tracker** (`.ai/trackers/<name>.md` written from `TEMPLATE.md`): 
 `TEMPLATE.md` against the version you built from, and implement any newly added operations for
 your tracker.
 
+Browser descriptors use the same process. Shipped copies live under
+`skills/om-setup-agent-pipeline/references/browsers/`; installed copies live at
+`.ai/browsers/<provider>.md`. Diff and merge by `### <operation>` section, or
+re-run `/om-setup-agent-pipeline` to choose and install a provider while
+preserving the rest of the config.
+
 ## Notable upgrades
 
 Newest first. Each entry lists the symptom you will see with a stale installation and the fix.
+
+### 2026-07 — Browser providers and first-class agent-browser
+
+Browser-capable skills now read `browser.provider` from
+`.ai/agentic.config.json` and execute named operations from
+`.ai/browsers/<provider>.md`. Fresh setups choose `agent-browser`, whose shipped
+descriptor installs its native CLI, Chrome for Testing, and available OS
+libraries autonomously on macOS, Linux, WSL2, Git Bash, and native Windows.
+Playwright remains available as a provider and as the implicit fallback for
+older configs.
+
+- **Symptom of a stale installation:** QA skills continue using their embedded
+  Playwright flow, or an explicit `browser.provider` cannot be resolved because
+  `.ai/browsers/<provider>.md` is missing.
+- **Fix:** run `/om-apply-upgrade-notes --yes` to add
+  `browser.provider: "playwright"` (behavior-preserving for an existing repo)
+  and install `.ai/browsers/playwright.md`; then change the provider to
+  `agent-browser` and install its descriptor when the team wants the new
+  default. A fresh `/om-setup-agent-pipeline` run may select agent-browser
+  directly. Custom providers must implement the operations in
+  `references/browsers/TEMPLATE.md`.
 
 ### 2026-07 — `attach-image-evidence` tracker operation (PR #14)
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "scripts": {
     "install-skills": "node scripts/install-skills.mjs",
     "uninstall-skills": "node scripts/install-skills.mjs --uninstall",
-    "lint": "scripts/lint.sh"
+    "lint": "scripts/lint.sh",
+    "test:browser-providers": "node scripts/test-browser-providers.mjs",
+    "test:agent-browser-codex": "bash scripts/test-agent-browser-codex.sh"
   }
 }

--- a/scripts/fixtures/agent-browser-codex/.ai/agentic.config.json
+++ b/scripts/fixtures/agent-browser-codex/.ai/agentic.config.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "baseBranch": "main",
+  "tracker": "",
+  "browser": { "provider": "agent-browser" },
+  "validation": { "commands": [] },
+  "labels": { "enabled": false },
+  "qaGate": false,
+  "paths": {
+    "runs": ".ai/runs",
+    "analysis": ".ai/analysis",
+    "specs": ".ai/specs",
+    "scripts": ".ai/scripts",
+    "qa": ".ai/qa"
+  },
+  "reviewChecklist": null
+}

--- a/scripts/fixtures/agent-browser-codex/AGENTS.md
+++ b/scripts/fixtures/agent-browser-codex/AGENTS.md
@@ -1,0 +1,13 @@
+# Fixture instructions
+
+This is an isolated static UI fixture for browser-provider verification.
+
+- Start the app with `node server.mjs`; it prints `FIXTURE_URL=<url>` and stays
+  running until terminated.
+- Generate `.ai/scripts/test-env-up.sh` and `test-env-down.sh` around that command.
+- Use a free port and bind to `127.0.0.1`.
+- The ready page has an `h1` and one button. No credentials or backing services
+  exist.
+- Browser evidence must use the configured `.ai/browsers/agent-browser.md`.
+- Never contact any URL except the local fixture and the official installation
+  hosts required by the browser descriptor.

--- a/scripts/fixtures/agent-browser-codex/index.changed.html
+++ b/scripts/fixtures/agent-browser-codex/index.changed.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8"><title>Browser fixture</title></head>
+  <body><main><h1>Agent Browser Fixture Updated</h1><button type="button">Continue</button></main></body>
+</html>

--- a/scripts/fixtures/agent-browser-codex/index.html
+++ b/scripts/fixtures/agent-browser-codex/index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8"><title>Browser fixture</title></head>
+  <body><main><h1>Agent Browser Fixture</h1><button type="button">Start</button></main></body>
+</html>

--- a/scripts/fixtures/agent-browser-codex/server.mjs
+++ b/scripts/fixtures/agent-browser-codex/server.mjs
@@ -1,0 +1,22 @@
+import { createServer } from "node:http";
+import { readFileSync } from "node:fs";
+
+const body = readFileSync(new URL("./index.html", import.meta.url));
+const server = createServer((request, response) => {
+  if (request.url === "/" || request.url === "/index.html") {
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(body);
+    return;
+  }
+  response.writeHead(404, { "content-type": "text/plain" });
+  response.end("not found");
+});
+
+server.listen(0, "127.0.0.1", () => {
+  const address = server.address();
+  console.log(`FIXTURE_URL=http://127.0.0.1:${address.port}`);
+});
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => server.close(() => process.exit(0)));
+}

--- a/scripts/test-agent-browser-codex.sh
+++ b/scripts/test-agent-browser-codex.sh
@@ -6,10 +6,11 @@ FIXTURE_SOURCE="$ROOT/scripts/fixtures/agent-browser-codex"
 TMP_ROOT=${TMPDIR:-/tmp}
 FIXTURE=$(mktemp -d "$TMP_ROOT/agent-browser-codex.XXXXXX")
 LOG_DIR="$FIXTURE/codex-logs"
-SERVER_PID=""
 
 cleanup() {
-  if [ -n "$SERVER_PID" ]; then kill "$SERVER_PID" 2>/dev/null || true; fi
+  if [ -f "$FIXTURE/.ai/scripts/test-env-down.sh" ]; then
+    (cd "$FIXTURE" && sh .ai/scripts/test-env-down.sh) >/dev/null 2>&1 || true
+  fi
   if [ "${KEEP_CODEX_E2E_FIXTURE:-0}" != 1 ]; then rm -rf "$FIXTURE"; fi
 }
 trap cleanup EXIT
@@ -25,6 +26,7 @@ done
 cp "$ROOT/skills/om-setup-agent-pipeline/references/browsers/agent-browser.md" "$FIXTURE/.ai/browsers/agent-browser.md"
 
 git -C "$FIXTURE" init -q
+git -C "$FIXTURE" branch -M main
 git -C "$FIXTURE" config user.name "Codex Browser Test"
 git -C "$FIXTURE" config user.email "codex-browser-test@example.invalid"
 git -C "$FIXTURE" add .

--- a/scripts/test-agent-browser-codex.sh
+++ b/scripts/test-agent-browser-codex.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel)
+FIXTURE_SOURCE="$ROOT/scripts/fixtures/agent-browser-codex"
+TMP_ROOT=${TMPDIR:-/tmp}
+FIXTURE=$(mktemp -d "$TMP_ROOT/agent-browser-codex.XXXXXX")
+LOG_DIR="$FIXTURE/codex-logs"
+SERVER_PID=""
+
+cleanup() {
+  if [ -n "$SERVER_PID" ]; then kill "$SERVER_PID" 2>/dev/null || true; fi
+  if [ "${KEEP_CODEX_E2E_FIXTURE:-0}" != 1 ]; then rm -rf "$FIXTURE"; fi
+}
+trap cleanup EXIT
+
+command -v codex >/dev/null 2>&1 || { echo "codex CLI is required" >&2; exit 1; }
+command -v node >/dev/null 2>&1 || { echo "node is required by the local fixture app" >&2; exit 1; }
+
+cp -R "$FIXTURE_SOURCE/." "$FIXTURE/"
+mkdir -p "$FIXTURE/.agents/skills" "$FIXTURE/.ai/browsers" "$LOG_DIR"
+for skill in om-setup-agent-pipeline om-prepare-test-env om-auto-verify-pr-ui om-integration-tests; do
+  ln -s "$ROOT/skills/$skill" "$FIXTURE/.agents/skills/$skill"
+done
+cp "$ROOT/skills/om-setup-agent-pipeline/references/browsers/agent-browser.md" "$FIXTURE/.ai/browsers/agent-browser.md"
+
+git -C "$FIXTURE" init -q
+git -C "$FIXTURE" config user.name "Codex Browser Test"
+git -C "$FIXTURE" config user.email "codex-browser-test@example.invalid"
+git -C "$FIXTURE" add .
+git -C "$FIXTURE" commit -qm "test: baseline fixture"
+cp "$FIXTURE/index.changed.html" "$FIXTURE/index.html"
+
+run_codex() {
+  local name=$1
+  local prompt=$2
+  codex exec --ephemeral --sandbox danger-full-access --ignore-user-config --json \
+    -C "$FIXTURE" "$prompt" > "$LOG_DIR/$name.jsonl"
+}
+
+run_codex prepare 'Use $om-prepare-test-env with --mode dev --no-ephemeral and --browser-provider agent-browser. This is an isolated test fixture; proceed without questions. The app command and port contract are in AGENTS.md. Finish only after the generated entrypoint passes cold and warm runs and test-env.json reports a healthy agent-browser provider.'
+
+test -s "$FIXTURE/.ai/qa/test-env.json"
+node -e 'const d=require(process.argv[1]); if(d.status!=="running"||d.browser?.provider!=="agent-browser"||d.browser?.installed!==true) process.exit(1)' "$FIXTURE/.ai/qa/test-env.json"
+
+run_codex verify 'Use $om-auto-verify-pr-ui in local evidence-only mode with --keep-env. Verify the uncommitted title and button-text change through the configured agent-browser provider. Proceed without questions. Require a PASS report and a non-empty PNG under .ai/qa; do not modify index.html.'
+
+REPORT=$(find "$FIXTURE/.ai/qa" -path '*/report.json' -type f | head -n 1)
+test -n "$REPORT"
+node -e 'const d=require(process.argv[1]); if(d.verdict!=="PASS"||d.environment?.browserProvider!=="agent-browser") process.exit(1)' "$REPORT"
+find "$FIXTURE/.ai/qa" -name '*.png' -type f -size +0c | grep -q .
+
+run_codex integration 'Use $om-integration-tests to add and run an executable UI regression test for the changed title and button. The configured provider is agent-browser and there is no repository-native E2E runner. You are pre-authorized to scaffold matching tests/browser/fixture-title.sh and tests/browser/fixture-title.ps1 launchers as the skill describes; proceed without questions, run the POSIX launcher, and leave both files passing and semantically equivalent. The PowerShell launcher must invoke the native .ps1 environment entrypoint when present and must not invoke sh, WSL, Git Bash, or POSIX utilities.'
+
+test -s "$FIXTURE/tests/browser/fixture-title.sh"
+test -s "$FIXTURE/tests/browser/fixture-title.ps1"
+grep -q 'agent-browser' "$FIXTURE/tests/browser/fixture-title.sh"
+grep -q 'agent-browser' "$FIXTURE/tests/browser/fixture-title.ps1"
+if grep -Eq '(^|[&[:space:]])sh[[:space:]]' "$FIXTURE/tests/browser/fixture-title.ps1"; then
+  echo "PowerShell launcher depends on sh" >&2
+  exit 1
+fi
+grep -q 'agent-browser' "$LOG_DIR/prepare.jsonl"
+grep -q 'agent-browser' "$LOG_DIR/verify.jsonl"
+grep -q 'agent-browser' "$LOG_DIR/integration.jsonl"
+
+printf 'Codex agent-browser E2E OK\nFixture: %s\nLogs: %s\n' "$FIXTURE" "$LOG_DIR"

--- a/scripts/test-browser-providers.mjs
+++ b/scripts/test-browser-providers.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = new URL("../", import.meta.url).pathname;
+const read = (path) => readFileSync(join(root, path), "utf8");
+
+const template = read("skills/om-setup-agent-pipeline/references/browsers/TEMPLATE.md");
+const agentBrowser = read("skills/om-setup-agent-pipeline/references/browsers/agent-browser.md");
+const playwright = read("skills/om-setup-agent-pipeline/references/browsers/playwright.md");
+const setup = read("skills/om-setup-agent-pipeline/SKILL.md");
+const prepare = read("skills/om-prepare-test-env/SKILL.md");
+const envDescriptor = read("skills/om-prepare-test-env/references/env-descriptor.md");
+const verifyUi = read("skills/om-auto-verify-pr-ui/SKILL.md");
+const integration = read("skills/om-integration-tests/SKILL.md");
+
+const operations = [
+  "ensure-installed",
+  "doctor",
+  "open",
+  "snapshot",
+  "interact",
+  "assert",
+  "screenshot",
+  "close",
+];
+
+for (const operation of operations) {
+  assert.match(template, new RegExp(`^### ${operation}$`, "m"), `template: ${operation}`);
+  assert.match(agentBrowser, new RegExp(`^### ${operation}$`, "m"), `agent-browser: ${operation}`);
+  assert.match(playwright, new RegExp(`^### ${operation}$`, "m"), `playwright: ${operation}`);
+}
+
+function releaseAsset(platform, arch, musl = false) {
+  const normalized = arch === "x86_64" || arch === "amd64" ? "x64"
+    : arch === "arm64" || arch === "aarch64" ? "arm64"
+      : "unsupported";
+  if (platform === "darwin") return `agent-browser-darwin-${normalized}`;
+  if (platform === "linux" || platform === "wsl2") {
+    return `agent-browser-${musl ? "linux-musl" : "linux"}-${normalized}`;
+  }
+  if (platform === "win32" && (normalized === "x64" || normalized === "arm64")) {
+    return "agent-browser-win32-x64.exe";
+  }
+  return "unsupported";
+}
+
+const matrix = [
+  ["darwin", "x86_64", false, "agent-browser-darwin-x64"],
+  ["darwin", "arm64", false, "agent-browser-darwin-arm64"],
+  ["linux", "x86_64", false, "agent-browser-linux-x64"],
+  ["linux", "aarch64", false, "agent-browser-linux-arm64"],
+  ["linux", "x86_64", true, "agent-browser-linux-musl-x64"],
+  ["linux", "aarch64", true, "agent-browser-linux-musl-arm64"],
+  ["wsl2", "x86_64", false, "agent-browser-linux-x64"],
+  ["wsl2", "aarch64", false, "agent-browser-linux-arm64"],
+  ["win32", "amd64", false, "agent-browser-win32-x64.exe"],
+  ["win32", "arm64", false, "agent-browser-win32-x64.exe"],
+];
+
+for (const [platform, arch, musl, expected] of matrix) {
+  assert.equal(releaseAsset(platform, arch, musl), expected, `${platform}/${arch}/${musl}`);
+}
+assert.equal(releaseAsset("freebsd", "x86_64"), "unsupported");
+assert.equal(releaseAsset("linux", "riscv64"), "agent-browser-linux-unsupported");
+
+assert.match(agentBrowser, /agent-browser-darwin-\$ARCH/);
+assert.match(agentBrowser, /agent-browser-\$LIBC-\$ARCH/);
+assert.match(agentBrowser, /agent-browser-win32-x64\.exe/);
+assert.match(agentBrowser, /Invoke-WebRequest/);
+assert.match(agentBrowser, /install --with-deps/);
+assert.match(agentBrowser, /sudo -n/);
+assert.match(agentBrowser, /doctor --json/);
+assert.match(agentBrowser, /ABS_SCREENSHOT_PATH/);
+assert.doesNotMatch(agentBrowser, /BROWSERBASE_API_KEY|BROWSER_USE_API_KEY|KERNEL_API_KEY/);
+assert.doesNotMatch(agentBrowser, /npm install|npx |node /);
+
+assert.match(setup, /\.browser\.provider \/\/ "playwright"/);
+assert.match(setup, /"browser": \{ "provider": "agent-browser" \}/);
+assert.match(prepare, /BROWSER_FILE="\.ai\/browsers\/\$\{BROWSER_PROVIDER\}\.md"/);
+assert.match(envDescriptor, /"browser": \{/);
+assert.match(envDescriptor, /legacy compatibility object/);
+for (const consumer of [verifyUi, integration]) {
+  assert.match(consumer, /\.ai\/browsers\/<provider>\.md|\.ai\/browsers\/\$\{BROWSER_PROVIDER\}\.md/);
+  for (const operation of ["open", "snapshot", "interact", "assert"]) {
+    assert.match(consumer, new RegExp(`\\*\\*${operation}\\*\\*`), `consumer operation ${operation}`);
+  }
+}
+
+console.log(`Browser provider contract OK (${operations.length} operations, ${matrix.length} platform targets).`);

--- a/scripts/test-browser-providers.mjs
+++ b/scripts/test-browser-providers.mjs
@@ -3,8 +3,9 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const root = new URL("../", import.meta.url).pathname;
+const root = fileURLToPath(new URL("../", import.meta.url));
 const read = (path) => readFileSync(join(root, path), "utf8");
 
 const template = read("skills/om-setup-agent-pipeline/references/browsers/TEMPLATE.md");
@@ -79,6 +80,7 @@ assert.doesNotMatch(agentBrowser, /npm install|npx |node /);
 
 assert.match(setup, /\.browser\.provider \/\/ "playwright"/);
 assert.match(setup, /"browser": \{ "provider": "agent-browser" \}/);
+assert.match(setup, /Invalid browser\.provider/);
 assert.match(prepare, /BROWSER_FILE="\.ai\/browsers\/\$\{BROWSER_PROVIDER\}\.md"/);
 assert.match(envDescriptor, /"browser": \{/);
 assert.match(envDescriptor, /legacy compatibility object/);

--- a/skills/om-apply-upgrade-notes/SKILL.md
+++ b/skills/om-apply-upgrade-notes/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: om-apply-upgrade-notes
-description: Apply the skills collection's UPGRADE_NOTES.md to the current repository after a skills upgrade. Re-syncs the installed tracker descriptor (.ai/trackers/<tracker>.md) with the newly shipped operations while preserving local edits, reports newly required operations for custom tracker providers, checks the pipeline config and other installed artifacts against the notable-upgrade entries, and summarizes exactly what changed. Use right after upgrading the skills ("apply the upgrade notes", "sync the tracker descriptor", "my skills are newer than my repo setup").
+description: Apply the skills collection's UPGRADE_NOTES.md after an upgrade. Re-syncs installed tracker and browser-provider descriptors while preserving local edits, reports custom-provider gaps, checks pipeline config and installed artifacts, and summarizes exactly what changed.
 ---
 
 # Apply Upgrade Notes
 
 Upgrading the skills collection updates the skill instructions, but not the artifacts a previous
-skill run **installed into this repository** — above all the tracker descriptor
-`.ai/trackers/<tracker>.md`, the file every tracker operation actually executes from. A stale
-descriptor fails silently: skills degrade or skip steps on operations it does not define, and
-nothing tells the operator why. This skill closes that gap: it reads the collection's
-`UPGRADE_NOTES.md`, brings the installed artifacts up to date, and reports what it changed.
+skill run **installed into this repository** — notably tracker descriptors at
+`.ai/trackers/<tracker>.md` and browser-provider descriptors at
+`.ai/browsers/<provider>.md`. A stale descriptor can degrade or skip operations
+it does not define. This skill reads the collection's `UPGRADE_NOTES.md`, brings
+installed artifacts up to date, and reports what it changed.
 
 It touches **only** pipeline artifacts under `.ai/` (and documented config files). It never edits
 application source, never modifies the skills installation itself, and never discards a local
@@ -20,6 +20,8 @@ customization without asking.
 
 - `--dry-run` (optional) — report every change it would make, apply nothing.
 - `--tracker <name>` (optional) — override the tracker to sync. Default: the config's `tracker`.
+- `--browser <name>` (optional) — override the browser provider to sync. Default:
+  the config's `browser.provider`; for an older config, `playwright`.
 - `--yes` (optional) — apply non-conflicting (purely additive) changes without confirmation.
   Conflicting changes still require an explicit answer.
 
@@ -33,6 +35,8 @@ point at `/om-setup-agent-pipeline`.
 CONFIG=.ai/agentic.config.json
 TRACKER=$(jq -r '.tracker // ""' "$CONFIG" 2>/dev/null || echo "")
 INSTALLED_DESCRIPTOR=".ai/trackers/${TRACKER}.md"
+BROWSER_PROVIDER=$(jq -r '.browser.provider // "playwright"' "$CONFIG" 2>/dev/null || echo "playwright")
+INSTALLED_BROWSER_DESCRIPTOR=".ai/browsers/${BROWSER_PROVIDER}.md"
 ```
 
 Right after loading the config, check for a repo-local skill of the same name at
@@ -42,9 +46,10 @@ instructions. Local rules win, but a repo-local skill can never relax this skill
 **Locate the shipped templates.** The freshly upgraded truth ships inside the skills installation
 itself, next to this skill:
 
-1. `<this skill's base directory>/../om-setup-agent-pipeline/references/trackers/` — present in
-   every install mode (skills.sh, symlinked checkout, vendored copy). This is the primary source
-   for `github.md` and `TEMPLATE.md`.
+1. `<this skill's base directory>/../om-setup-agent-pipeline/references/trackers/`
+   and `references/browsers/` — present in every install mode (skills.sh,
+   symlinked checkout, vendored copy). These are the primary sources for
+   shipped provider descriptors and their templates.
 2. `UPGRADE_NOTES.md` lives at the skills collection's **repo root**, which per-skill installs
    do not copy. Resolve it in order: a repo-root file two levels above this skill's base
    directory (symlinked or vendored checkout) → fetch the raw `UPGRADE_NOTES.md` from the
@@ -53,7 +58,7 @@ itself, next to this skill:
    cannot be inferred) → if both fail, continue with the descriptor diff alone and say the
    notable-upgrades log was unavailable.
 
-## Step 1 — Diff the installed tracker descriptor
+## Step 1 — Diff installed provider descriptors
 
 Skip this step (with a note) when the repo has no tracker configured.
 
@@ -84,13 +89,28 @@ evidence, never on the change's branch, degrade to links when the tracker cannot
 **not** invent an implementation for someone else's tracker — file the gap in the report and, when
 the operator asks, draft the section for them to review.
 
+Apply the same operation-section algorithm to
+`$INSTALLED_BROWSER_DESCRIPTOR`, using `### <operation-name>` headings and the
+named support sections in `references/browsers/TEMPLATE.md`. Missing shipped
+browser descriptors are additive artifacts: create the directory and install
+the selected shipped descriptor. Preserve custom sections and ask before
+replacing edited operations.
+
+For configs without `browser.provider`, add
+`"browser": { "provider": "playwright" }` by default so the upgrade preserves
+existing behavior, then install the shipped Playwright descriptor. Do not
+silently switch an existing repository to agent-browser. The operator can choose
+agent-browser explicitly with `--browser agent-browser` or by re-running
+`om-setup-agent-pipeline`. A custom browser provider gets a gap report against
+`references/browsers/TEMPLATE.md`; never invent its installation or commands.
+
 ## Step 2 — Walk the notable-upgrades log
 
 For each entry in `UPGRADE_NOTES.md` (newest first), check whether its "symptom of a stale
 installation" can apply to this repository, and verify the corresponding artifact:
 
-- Descriptor-related entries are already covered by Step 1 — cross the entry off when the diff
-  handled it.
+- Tracker- or browser-descriptor entries are already covered by Step 1 — cross
+  the entry off when the diff handled it.
 - Config-related entries: check `.ai/agentic.config.json` for keys the entry introduces (new
   `paths.*` entries, new label groups). Add missing keys with their documented defaults —
   additive only; never rewrite values the team set.
@@ -101,9 +121,10 @@ installation" can apply to this repository, and verify the corresponding artifac
 ## Step 3 — Apply, verify, report
 
 - Apply the approved changes. With `--dry-run`, print the would-be changes instead.
-- Sanity-check the result: the descriptor still has every operation the installed skills name
-  (grep the installed skills' SKILL.md files for `**operation-name**` references when in doubt),
-  and the config still parses (`jq . "$CONFIG"`).
+- Sanity-check the result: each descriptor still has every operation the
+  installed skills name (grep the installed skills' `SKILL.md` files for
+  `**operation-name**` references when in doubt), the browser provider resolves
+  to an existing descriptor, and the config still parses (`jq . "$CONFIG"`).
 - Leave the changes uncommitted for review, then print a concise summary:
 
 ```text
@@ -114,20 +135,23 @@ Kept local customizations: …                          (or: none)
 Conflicts resolved by operator: …                     (or: none)
 Config keys added: …                                  (or: none)
 Custom-tracker gaps to implement: …                   (or: n/a)
+Browser descriptor: <provider> @ .ai/browsers/<provider>.md
+Browser operations added/replaced/kept: …             (or: none)
+Custom-browser gaps to implement: …                   (or: n/a)
 Notable-upgrade entries checked: N (M applied, K already current)
 Next: review the diff and commit (e.g. /om-check-and-commit), then re-run the skill that degraded.
 ```
 
 ## Rules
 
-- Touch only pipeline artifacts: `.ai/trackers/*.md`, `.ai/agentic.config.json`, and artifacts
-  named by an UPGRADE_NOTES entry. Never edit application source, tests, or the skills
-  installation.
+- Touch only pipeline artifacts: `.ai/trackers/*.md`, `.ai/browsers/*.md`,
+  `.ai/agentic.config.json`, and artifacts named by an UPGRADE_NOTES entry. Never
+  edit application source, tests, or the skills installation.
 - Preserve local customizations: a section that differs from stock is the team's — ask before
   replacing it, and always keep local-only operations.
 - Additive by default: add missing operations and missing config keys; never delete or rewrite
   what the team configured.
-- Custom tracker providers get a gap report, not an auto-generated implementation.
+- Custom tracker and browser providers get a gap report, not an auto-generated implementation.
 - Idempotent: a second run right after a successful one must report "already current" and change
   nothing.
 - Leave changes uncommitted for the operator's review; suggest the commit, don't make it.

--- a/skills/om-auto-verify-pr-ui/SKILL.md
+++ b/skills/om-auto-verify-pr-ui/SKILL.md
@@ -57,6 +57,9 @@ CONFIG=.ai/agentic.config.json
 TRACKER=$(jq -r '.tracker // ""' "$CONFIG" 2>/dev/null || echo "")
 QA_DIR=$(jq -r '.paths.qa // ".ai/qa"' "$CONFIG" 2>/dev/null || echo ".ai/qa")
 BROWSER_PROVIDER=$(jq -r '.browser.provider // "playwright"' "$CONFIG" 2>/dev/null || echo "playwright")
+case "$BROWSER_PROVIDER" in
+  ''|*[!A-Za-z0-9._-]*) echo "Invalid browser.provider: $BROWSER_PROVIDER" >&2; exit 1 ;;
+esac
 BROWSER_FILE=".ai/browsers/${BROWSER_PROVIDER}.md"
 LABELS_ENABLED=$(jq -r '.labels.enabled // false' "$CONFIG" 2>/dev/null || echo false)
 RUN_ID="$(date -u +%Y%m%d-%H%M%S)-$$"
@@ -175,8 +178,10 @@ QA_DIR=$(jq -r '.paths.qa // ".ai/qa"' .ai/agentic.config.json 2>/dev/null || ec
 ENV_DESCRIPTOR="$QA_DIR/test-env.json"
 BASE_URL=$(jq -r '.baseUrl' "$ENV_DESCRIPTOR")
 BROWSER_PROVIDER=$(jq -r '.browser.provider // (if .playwright.runner then "playwright" else empty end) // "playwright"' "$ENV_DESCRIPTOR")
-BROWSER_FILE=$(jq -r '.browser.descriptor // empty' "$ENV_DESCRIPTOR")
-[ -z "$BROWSER_FILE" ] && BROWSER_FILE=".ai/browsers/${BROWSER_PROVIDER}.md"
+case "$BROWSER_PROVIDER" in
+  ''|*[!A-Za-z0-9._-]*) echo "Invalid browser provider in $ENV_DESCRIPTOR: $BROWSER_PROVIDER" >&2; exit 1 ;;
+esac
+BROWSER_FILE=".ai/browsers/${BROWSER_PROVIDER}.md"
 BROWSER_COMMAND=$(jq -r '.browser.command // .playwright.runner // empty' "$ENV_DESCRIPTOR")
 BROWSER_INSTALLED=$(jq -r '.browser.installed // .playwright.installed // false' "$ENV_DESCRIPTOR")
 ```

--- a/skills/om-auto-verify-pr-ui/SKILL.md
+++ b/skills/om-auto-verify-pr-ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: om-auto-verify-pr-ui
-description: Manually QA a change's UI by running the app locally and driving it with a real browser — without merging anything. Boots a local instance of the app in the current worktree (via om-prepare-test-env), derives a UI QA scenario from the diff, drives it with Playwright while capturing screenshots, and produces a pass/fail verification report. When a tracker and PR number are given, it claims the PR, posts the screenshots + report as a PR comment, and (opt-in) applies QA labels; when there is no tracker, it stores the screenshots plus a JSON and Markdown report in an artifacts folder. Use when the user says "verify PR <n> in the UI", "QA PR <n>", "screenshot PR <n>", "self-QA PR <n>", or "verify my changes in the UI".
+description: Manually QA a UI change in a real browser through the configured browser-provider descriptor, capture screenshots and a pass/fail report, and optionally post tracker evidence or self-QA labels without modifying source.
 ---
 
 # Verify UI
@@ -56,6 +56,8 @@ present, it also resolves the tracker and the paths:
 CONFIG=.ai/agentic.config.json
 TRACKER=$(jq -r '.tracker // ""' "$CONFIG" 2>/dev/null || echo "")
 QA_DIR=$(jq -r '.paths.qa // ".ai/qa"' "$CONFIG" 2>/dev/null || echo ".ai/qa")
+BROWSER_PROVIDER=$(jq -r '.browser.provider // "playwright"' "$CONFIG" 2>/dev/null || echo "playwright")
+BROWSER_FILE=".ai/browsers/${BROWSER_PROVIDER}.md"
 LABELS_ENABLED=$(jq -r '.labels.enabled // false' "$CONFIG" 2>/dev/null || echo false)
 RUN_ID="$(date -u +%Y%m%d-%H%M%S)-$$"
 ARTIFACTS_DIR="$QA_DIR/artifacts_${RUN_ID}"
@@ -164,15 +166,25 @@ not count — the follow-up is specifically about a missing browser-level test.
 
 Do not boot the app by hand. Invoke the `om-prepare-test-env` skill (mode `auto`;
 pass `--no-ephemeral` when the app clearly needs no backing services). It
-discovers or provisions a runnable instance, installs Playwright when missing, and
+discovers or provisions a runnable instance, installs the configured browser
+provider when missing, and
 writes the environment descriptor. Then read the descriptor:
 
 ```bash
 QA_DIR=$(jq -r '.paths.qa // ".ai/qa"' .ai/agentic.config.json 2>/dev/null || echo ".ai/qa")
 ENV_DESCRIPTOR="$QA_DIR/test-env.json"
 BASE_URL=$(jq -r '.baseUrl' "$ENV_DESCRIPTOR")
-PW_CONFIG=$(jq -r '.playwright.config // ""' "$ENV_DESCRIPTOR")
+BROWSER_PROVIDER=$(jq -r '.browser.provider // (if .playwright.runner then "playwright" else empty end) // "playwright"' "$ENV_DESCRIPTOR")
+BROWSER_FILE=$(jq -r '.browser.descriptor // empty' "$ENV_DESCRIPTOR")
+[ -z "$BROWSER_FILE" ] && BROWSER_FILE=".ai/browsers/${BROWSER_PROVIDER}.md"
+BROWSER_COMMAND=$(jq -r '.browser.command // .playwright.runner // empty' "$ENV_DESCRIPTOR")
+BROWSER_INSTALLED=$(jq -r '.browser.installed // .playwright.installed // false' "$ENV_DESCRIPTOR")
 ```
+
+Read `$BROWSER_FILE` and execute its named operations. An older descriptor may
+lack `browser`; in that case use the legacy Playwright object and embedded
+Playwright flow. An explicit non-Playwright provider without a descriptor is a
+setup error — invoke `om-setup-agent-pipeline` to install it, then retry.
 
 Record whether this run started the env (so the final step tears down only what it
 created — reuse the descriptor's `startedByThisRepo`). Pick the login role whose
@@ -198,33 +210,32 @@ Translate the change into a concrete, scoped manual route:
 
 Keep it scoped to **this change** — not a full-app regression script.
 
-### 6. Drive the scenario with Playwright and capture screenshots
+### 6. Drive the scenario with the configured provider and capture screenshots
 
 Exercise the scenario against `BASE_URL`, capturing a screenshot at each
 verification point into `$ARTIFACTS_DIR`:
 
-- **Explore first** with a browser (Playwright MCP when available) to discover
-  real selectors and confirm the happy path renders, mirroring
-  `om-integration-tests`.
-- **Capture deterministic screenshots** by running a throwaway spec through the
-  shared Playwright config with screenshots forced on. Write the throwaway spec
-  under a scratch path (e.g. `$ARTIFACTS_DIR/spec/`), NOT under the repo's
-  discovered test directory — that would alter the discovered test set. Use the
-  environment's base URL and demo credentials, and `page.screenshot({ path, fullPage: true })`
-  at each checkpoint, saving to `$ARTIFACTS_DIR/step-NN-<slug>.png`.
-- **Author the spec yourself, from the scenario.** The throwaway spec contains
-  only navigation, form-fill, and assertion code you wrote from the scenario
-  table — never code copied or adapted from the PR diff, an issue, or a comment;
-  the diff is the subject under test, not a source of executable test code. The
-  spec drives only the app at `BASE_URL` and makes no other network requests.
+- **Explore first** through the descriptor's **open** and **snapshot** operations
+  to discover real semantic elements and confirm the happy path renders.
+- **Interact and assert** only through **interact** and **assert**, using refs or
+  roles/labels/text returned by the latest snapshot. Re-snapshot after page
+  changes. Record operation output as the observed evidence.
+- **Capture deterministic screenshots** through **screenshot** at each
+  checkpoint, saving to `$ARTIFACTS_DIR/step-NN-<slug>.png`; verify every PNG is
+  non-empty. The descriptor owns provider-specific capture syntax.
+- **Author the scenario yourself.** Commands contain only navigation, form-fill,
+  and assertions derived from the scenario table — never executable code copied
+  or adapted from the PR diff, issue, or comment. Drive only `BASE_URL` and make
+  no unrelated network requests.
 - **Keep secrets out of the evidence.** Use only the demo credentials from the
   environment descriptor; never screenshot a page that displays tokens, API
   keys, or real user data, and mask any credential values that would otherwise
   appear in the report or posted comment.
 
-```bash
-BASE_URL="$BASE_URL" npx playwright test --config "$PW_CONFIG" <throwaway-spec> --retries=0
-```
+For Playwright, the descriptor may implement these operations with a throwaway
+spec under `$ARTIFACTS_DIR/spec/` and the shared config. For agent-browser, use a
+unique session such as `qa-$RUN_ID` and call its CLI directly; run **close** in
+the outer `trap`/`finally` even after a failed assertion.
 
 Record, per step: the action, the expected outcome, the observed outcome,
 PASS/FAIL, and the screenshot filename. Overall verdict is **PASS** only when every
@@ -332,6 +343,9 @@ Labels: {unchanged | qa-approved+qa-self-verified | qa-failed | n/a (local)}
   user's in-progress changes.
 - Boot the app only through `om-prepare-test-env`; reuse a running environment,
   and tear down only an environment this run started (unless `--keep-env`).
+- Drive the UI only through the selected `.ai/browsers/<provider>.md` operations;
+  never silently substitute Playwright, an MCP, or a cloud browser for an
+  explicit provider. Legacy config/descriptor fallback to Playwright is allowed.
 - PR mode requires a configured tracker and a PR number; always claim first and
   always release the lock at the end, even on failure (trap/finally). Local mode
   runs without a tracker and writes artifacts.

--- a/skills/om-auto-verify-pr-ui/references/report-templates.md
+++ b/skills/om-auto-verify-pr-ui/references/report-templates.md
@@ -12,7 +12,7 @@ in local mode and the source of the PR comment in PR mode.
   "mode": "pr | local",
   "target": { "prNumber": 1234, "title": "…", "branch": "…", "headSha": "…" },
   "verdict": "PASS | FAIL | PARTIAL",
-  "environment": { "baseUrl": "…", "role": "…", "startedByThisRepo": true },
+  "environment": { "baseUrl": "…", "role": "…", "startedByThisRepo": true, "browserProvider": "agent-browser | playwright | custom" },
   "scenario": [
     { "step": 1, "priority": "P1", "action": "…", "expected": "…", "observed": "…", "result": "PASS", "screenshot": "step-01-…​.png" }
   ],
@@ -29,7 +29,7 @@ template:
 ## 🖼️ UI QA evidence — {verdict}
 
 **Verdict:** {✅ PASS | ❌ FAIL | ⚠️ PARTIAL — environment-limited}
-**Environment:** `{baseUrl}` · role `{role}`
+**Environment:** `{baseUrl}` · role `{role}` · browser `{provider}`
 **Verified:** {branch} @ {headSha (short)}
 
 ### Scenario ({P0|P1|P2} — {area})

--- a/skills/om-integration-tests/SKILL.md
+++ b/skills/om-integration-tests/SKILL.md
@@ -38,6 +38,13 @@ Windows without a project runtime dependency. For Playwright, use a minimal
 shared TypeScript config. Never replace an existing runner merely because a
 different exploration provider is selected.
 
+The paired launchers must be native, not wrappers around each other. The POSIX
+launcher invokes the generated `.sh` environment entrypoint; the PowerShell
+launcher invokes `.ai/scripts/test-env-up.ps1`. A `.ps1` must never assume `sh`,
+WSL, Git Bash, or POSIX utilities exist. When the matching environment launcher
+has not been generated yet, the test reports that `om-prepare-test-env` must be
+run once on that platform; it does not call the other platform's launcher.
+
 Runtime policy: timeouts and retries belong in the **shared runner config**, not in individual test files — no per-test timeout or retry overrides. While authoring or debugging a single test, fail fast by overriding retries to 0 on the command line, never by editing the shared config.
 
 ## Discover how to run the app

--- a/skills/om-integration-tests/SKILL.md
+++ b/skills/om-integration-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: om-integration-tests
-description: Run and create integration/E2E tests (Playwright TypeScript by default) — execute the suite, generate new tests from specs or feature descriptions by exploring the running application first, and report failures with artifact-based per-test diagnosis. Reuses an already-running test environment and caches build artifacts (state files, PID-checked locks, freshness fingerprints) to keep bootstrap fast. Use when the user says "run integration tests", "test this feature", "create test for", or "integration test".
+description: Run and create integration/E2E tests by exploring the live app with the configured browser provider, preserving repository-native runners, reusing the shared test environment, and diagnosing failures from concrete artifacts.
 ---
 
 # Integration Tests
@@ -17,9 +17,9 @@ Check for a repo-local skill of the same name at `.ai/skills/om-integration-test
 
 ## Reuse the shared test environment
 
-Before discovering how to run the app yourself, check for a shared environment descriptor written by `om-prepare-test-env` at `<paths.qa>/test-env.json` (default `.ai/qa/test-env.json`). When it reports `"status":"running"` and passes the validation in the fast-bootstrap contract below (PID alive, readiness probe answers, still fresh), **attach to that instance** — read `baseUrl`, `credentials`, and the browser-runner `config` from it, and run tests against that same booted app. This is how QA (`om-auto-verify-pr-ui`) and integration tests share one environment instead of each booting their own, so runs are faster and identical.
+Before discovering how to run the app yourself, check for a shared environment descriptor written by `om-prepare-test-env` at `<paths.qa>/test-env.json` (default `.ai/qa/test-env.json`). When it reports `"status":"running"` and passes the validation in the fast-bootstrap contract below (PID alive, readiness probe answers, still fresh), **attach to that instance** — read `baseUrl`, `credentials`, the provider-neutral `browser` object, and `testRunner` from it. Resolve older descriptors through the legacy `playwright` object. This is how QA (`om-auto-verify-pr-ui`) and integration tests share one environment instead of each booting their own, so runs are faster and identical.
 
-When no descriptor exists (or it is stale), invoke `om-prepare-test-env` to discover or provision one — it establishes the run command, provisions any backing services, installs Playwright when missing, and writes the descriptor — then attach to it. Fall back to the manual discovery below only when `om-prepare-test-env` is unavailable or the user asked to run against an already-running instance. Never hardcode a guessed `localhost:<port>`; take the base URL from the descriptor or the runner config the repo already uses.
+When no descriptor exists (or it is stale), invoke `om-prepare-test-env` to discover or provision one — it establishes the run command, provisions backing services, installs the configured browser provider through `.ai/browsers/<provider>.md`, and writes the descriptor — then attach to it. Fall back to the manual discovery below only when `om-prepare-test-env` is unavailable or the user asked to run against an already-running instance. Never hardcode a guessed `localhost:<port>`; take the base URL from the descriptor or the runner config the repo already uses.
 
 ## Discover the test setup
 
@@ -29,7 +29,14 @@ Before writing anything, find how this repo already does integration testing:
 - Test scripts in `package.json`, a `Makefile`, or CI workflows — prefer whatever command CI runs.
 - Existing test files: mirror their location, naming, fixtures, and helper conventions exactly.
 
-When the repo has no integration test setup at all, propose Playwright (TypeScript) with a minimal shared config and ask before scaffolding it.
+When the repo has no integration-test setup, propose a minimal executable setup
+for the configured provider and ask before scaffolding it. For agent-browser,
+create matching POSIX `sh` and native PowerShell scenario launchers that perform
+the same observed semantic actions/assertions through the provider descriptor;
+this keeps the test runnable on macOS, Linux, WSL2, Git Bash, and native
+Windows without a project runtime dependency. For Playwright, use a minimal
+shared TypeScript config. Never replace an existing runner merely because a
+different exploration provider is selected.
 
 Runtime policy: timeouts and retries belong in the **shared runner config**, not in individual test files — no per-test timeout or retry overrides. While authoring or debugging a single test, fail fast by overriding retries to 0 on the command line, never by editing the shared config.
 
@@ -73,11 +80,13 @@ Follow the repository's existing naming convention for test cases. When there is
 
 ### Phase 3 — Explore the feature in the running app
 
-Use the base URL established above. For UI tests, drive a real browser (browser automation / MCP tooling when available):
+Use the base URL established above. For UI tests, read the selected browser
+descriptor and drive its **open**, **snapshot**, **interact**, and **assert**
+operations (use MCP tooling only when it implements the selected provider):
 
 1. Log in with the appropriate role.
 2. Navigate to the relevant page.
-3. Take snapshots to capture exact element labels, button text, and form fields.
+3. Take provider snapshots to capture exact element references, labels, button text, and form fields.
 4. Walk the happy path to discover the actual flow.
 5. Note validation messages, success states, and redirects.
 
@@ -86,7 +95,11 @@ For API tests, discover with real requests: the exact endpoint path and method, 
 ### Phase 4 — Write the test
 
 - Place the file where this repo keeps integration tests (Phase 0 discovery); mirror existing structure.
-- Use the locators actually observed in Phase 3 — role/label/text-based locators (`getByRole`, `getByLabel`, `getByText`), never guessed CSS paths.
+- Use only elements actually observed in Phase 3 — semantic roles, labels, text,
+  or provider refs; never guessed CSS paths. For agent-browser scenario scripts,
+  prefer its semantic `find` commands and re-snapshot before using refreshed
+  refs. For repository-native Playwright tests, use `getByRole`, `getByLabel`,
+  and `getByText`.
 - Do not hardcode entity IDs in routes, payloads, or assertions. Create fixtures at runtime (prefer API setup for stability) or select existing rows via stable text/role locators.
 - Do not rely on seeded/demo data for prerequisites; create what the test needs.
 - Clean up everything the test created in `finally`/teardown.
@@ -100,7 +113,11 @@ Only when documentation is wanted, and only if the repo has a place for it (a QA
 
 ### Phase 6 — Verify
 
-Run the new test with the repo's runner command, fail-fast (retries 0) while iterating. If it fails, fix it — never leave a broken test behind.
+Run the new test with the repo's runner command or the selected provider's
+executable scenario launcher. Use command-level fail-fast behavior while
+iterating. Capture screenshots through **screenshot** at key assertions. If it
+fails, fix it — never leave a broken test behind. Always invoke **close** from a
+`trap`/`finally` block.
 
 ## Rendering and performance gates
 
@@ -149,7 +166,11 @@ A typical spec produces 3–8 test cases. Happy paths first; edge cases as separ
 - MUST NOT rely on seeded/demo data; create required fixtures per test (prefer API setup) and clean them up in teardown.
 - MUST keep tests deterministic and isolated from run order and retries.
 - MUST NOT add per-test timeout/retry overrides; the shared runner config owns them. Debug with command-level retries 0.
-- MUST use locators observed in real snapshots (`getByRole`, `getByLabel`, `getByText`).
+- MUST read `.ai/browsers/<provider>.md` and use its named operations for
+  agent-driven UI exploration; only the implicit legacy Playwright provider may
+  use embedded fallback instructions when an older repo has no descriptor.
+- MUST use elements observed in real snapshots (semantic roles/labels/text or
+  provider refs; Playwright tests use `getByRole`, `getByLabel`, `getByText`).
 - MUST verify the new test passes before finishing; never leave broken tests.
 - MUST analyze failure artifacts before reporting, and report failures in the per-test table with reason, evidence, and suggested owner — also when only running existing tests.
 - The executable test is mandatory; the markdown scenario is optional documentation.

--- a/skills/om-prepare-test-env/SKILL.md
+++ b/skills/om-prepare-test-env/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: om-prepare-test-env
-description: Prepare a reusable, technology-agnostic environment for running and testing the app locally — expensive exactly once. On first use it discovers how the project runs (its own ephemeral/test tooling, Docker/compose, dev server, or a production build), then COMPILES that knowledge into a project-specific entrypoint script (default `.ai/scripts/test-env-up.sh`; a PowerShell `test-env-up.ps1` on native Windows) that embeds reuse checks, a generic build cache, service provisioning, health waits, and the environment-descriptor write. Every later invocation just executes that script — no re-discovery, no re-reasoning. Installs a browser test runner (Playwright by default) when missing, and writes a shared environment descriptor (`.ai/qa/test-env.json`) so QA and integration-test skills attach to the exact same instance. Use when the user says "prepare the test env", "spin up the app for testing", "set up an ephemeral environment", "get the app running so I can QA it", or when another skill needs a running instance.
+description: Prepare a reusable, technology-agnostic environment for local tests and QA. Compiles discovery into cross-platform launch scripts, provisions the configured browser provider autonomously, and writes the shared test-env descriptor consumed by UI and integration-test skills.
 ---
 
 # Prepare Test Environment
@@ -69,6 +69,8 @@ From a POSIX shell (macOS, Linux, WSL2, Git Bash):
 CONFIG=.ai/agentic.config.json
 SCRIPTS_DIR=$(jq -r '.paths.scripts // ".ai/scripts"' "$CONFIG" 2>/dev/null || echo ".ai/scripts")
 QA_DIR=$(jq -r '.paths.qa // ".ai/qa"' "$CONFIG" 2>/dev/null || echo ".ai/qa")
+BROWSER_PROVIDER=$(jq -r '.browser.provider // "playwright"' "$CONFIG" 2>/dev/null || echo "playwright")
+BROWSER_FILE=".ai/browsers/${BROWSER_PROVIDER}.md"
 UP_SCRIPT="$SCRIPTS_DIR/test-env-up.sh"
 DOWN_SCRIPT="$SCRIPTS_DIR/test-env-down.sh"
 ENV_DESCRIPTOR="$QA_DIR/test-env.json"
@@ -81,11 +83,14 @@ built-ins; forward-slash paths work fine in PowerShell and stay portable):
 
 ```powershell
 $ScriptsDir = ".ai/scripts"; $QaDir = ".ai/qa"
+$BrowserProvider = "playwright"
 if (Test-Path ".ai/agentic.config.json") {
   $cfg = Get-Content ".ai/agentic.config.json" -Raw | ConvertFrom-Json
   if ($cfg.paths -and $cfg.paths.scripts) { $ScriptsDir = $cfg.paths.scripts }
   if ($cfg.paths -and $cfg.paths.qa)      { $QaDir = $cfg.paths.qa }
+  if ($cfg.browser -and $cfg.browser.provider) { $BrowserProvider = $cfg.browser.provider }
 }
+$BrowserFile = ".ai/browsers/$BrowserProvider.md"
 $UpScript      = "$ScriptsDir/test-env-up.ps1"
 $DownScript    = "$ScriptsDir/test-env-down.ps1"
 $EnvDescriptor = "$QaDir/test-env.json"
@@ -128,8 +133,12 @@ and keep it quoted.
 - `--no-ephemeral` — never provision disposable services (generation-time choice).
 - `--stop` / `--down` — run the teardown script for the environment this repo's
   descriptor recorded as started by a previous run, then exit.
-- `--playwright <on|off>` (default `on`) — ensure a browser test runner during
-  generation when the repo has none.
+- `--browser <on|off>` (default `on`) — ensure the configured browser provider
+  during generation.
+- `--browser-provider <name>` (optional) — override `browser.provider` for this
+  generation. The matching `.ai/browsers/<name>.md` must exist.
+- `--playwright <on|off>` — compatibility alias. `on` selects the Playwright
+  provider for this generation; `off` behaves like `--browser off`.
 - `--force` — restart even if a healthy environment is running (passed through
   to the entrypoint script).
 - `--force-rebuild` — ignore the build cache and run the full preparation/build
@@ -222,7 +231,7 @@ phase ends. Run the full procedure in
   preparation chain, backing services, launch command/port, build inputs.
 - **2.3 Write the scripts** — generate `$UP_SCRIPT`/`$DOWN_SCRIPT` implementing
   the entrypoint contract (`references/entrypoint-contract.md`).
-- **2.4 Ensure a browser test runner** — Playwright by default, once, here.
+- **2.4 Ensure the configured browser provider** — once, through its descriptor.
 - **2.5 Verify the script — cold and warm** — the gate: the warm run must reuse,
   not rebuild.
 - **2.6 Report** — script paths, descriptor, base URL, cold/warm timings.
@@ -316,8 +325,10 @@ scheduled for every future run.
 - The script always writes `$ENV_DESCRIPTOR` so QA and integration-test skills
   attach to the same instance; never store real secrets in it — disposable/demo
   values only.
-- Ensure the browser runner at generation time (Playwright by default); when
-  browsers cannot be installed, record the blocker instead of faking readiness.
+- Ensure the configured browser provider at generation time through
+  `.ai/browsers/<provider>.md`; when installation or its live-launch check fails,
+  record the blocker instead of faking readiness. An implicit Playwright provider
+  may use the legacy embedded flow when an older repo has no descriptor.
 - Only tear down what this repo started; never touch a developer's own running
   services.
 - Every lesson the fast path teaches goes into the script and the repo-local

--- a/skills/om-prepare-test-env/SKILL.md
+++ b/skills/om-prepare-test-env/SKILL.md
@@ -70,6 +70,9 @@ CONFIG=.ai/agentic.config.json
 SCRIPTS_DIR=$(jq -r '.paths.scripts // ".ai/scripts"' "$CONFIG" 2>/dev/null || echo ".ai/scripts")
 QA_DIR=$(jq -r '.paths.qa // ".ai/qa"' "$CONFIG" 2>/dev/null || echo ".ai/qa")
 BROWSER_PROVIDER=$(jq -r '.browser.provider // "playwright"' "$CONFIG" 2>/dev/null || echo "playwright")
+case "$BROWSER_PROVIDER" in
+  ''|*[!A-Za-z0-9._-]*) echo "Invalid browser.provider: $BROWSER_PROVIDER" >&2; exit 1 ;;
+esac
 BROWSER_FILE=".ai/browsers/${BROWSER_PROVIDER}.md"
 UP_SCRIPT="$SCRIPTS_DIR/test-env-up.sh"
 DOWN_SCRIPT="$SCRIPTS_DIR/test-env-down.sh"
@@ -90,6 +93,7 @@ if (Test-Path ".ai/agentic.config.json") {
   if ($cfg.paths -and $cfg.paths.qa)      { $QaDir = $cfg.paths.qa }
   if ($cfg.browser -and $cfg.browser.provider) { $BrowserProvider = $cfg.browser.provider }
 }
+if ($BrowserProvider -notmatch '^[A-Za-z0-9._-]+$') { throw "Invalid browser.provider: $BrowserProvider" }
 $BrowserFile = ".ai/browsers/$BrowserProvider.md"
 $UpScript      = "$ScriptsDir/test-env-up.ps1"
 $DownScript    = "$ScriptsDir/test-env-down.ps1"
@@ -136,7 +140,8 @@ and keep it quoted.
 - `--browser <on|off>` (default `on`) — ensure the configured browser provider
   during generation.
 - `--browser-provider <name>` (optional) — override `browser.provider` for this
-  generation. The matching `.ai/browsers/<name>.md` must exist.
+  generation. Validate it against `^[A-Za-z0-9._-]+$` before building the path;
+  the matching `.ai/browsers/<name>.md` must exist.
 - `--playwright <on|off>` — compatibility alias. `on` selects the Playwright
   provider for this generation; `off` behaves like `--browser off`.
 - `--force` — restart even if a healthy environment is running (passed through

--- a/skills/om-prepare-test-env/references/entrypoint-contract.md
+++ b/skills/om-prepare-test-env/references/entrypoint-contract.md
@@ -116,7 +116,13 @@ of this section. In order:
    TEST_ENV_BASE_URL=http://127.0.0.1:4321
    TEST_ENV_DESCRIPTOR=.ai/qa/test-env.json
    TEST_ENV_REUSED=1        # 0 on a fresh boot
+   BROWSER_PROVIDER=agent-browser
+   BROWSER_INSTALLED=1
    ```
+
+   Preserve the provider state verified during generation. The warm entrypoint
+   does not reinstall it; when **doctor** later fails, return to generation in
+   repair mode and repair the provider installation through its descriptor.
 
 The down script (`test-env-down.sh` / `test-env-down.ps1`) mirrors it: stop the
 app PID, remove exactly the

--- a/skills/om-prepare-test-env/references/env-descriptor.md
+++ b/skills/om-prepare-test-env/references/env-descriptor.md
@@ -25,6 +25,15 @@ always attach to the same instance:
     { "type": "postgres", "host": "127.0.0.1", "port": 55432, "container": "<name>", "url": "postgres://…", "env": { "DATABASE_URL": "…" } }
   ],
   "credentials": [ { "role": "admin", "username": "<demo>", "password": "<demo>" } ],
+  "browser": {
+    "provider": "agent-browser",
+    "installed": true,
+    "command": "<absolute cached command path or repository runner command>",
+    "version": "<version>",
+    "descriptor": ".ai/browsers/agent-browser.md",
+    "notes": ""
+  },
+  "testRunner": { "name": "playwright | cypress | wdio | other | none", "config": "<path or empty>" },
   "playwright": { "runner": "playwright", "installed": true, "config": ".ai/qa/playwright.config.ts", "browsers": ["chromium"] },
   "platform": "linux | darwin | wsl2 | win32",
   "startedAt": "<ISO-8601 UTC>",
@@ -37,6 +46,14 @@ generated** — the `.ps1` paths when the entrypoint is the PowerShell flavor �
 and `platform` records where the environment was booted (`win32` covers both
 native PowerShell and Git Bash; the script extension disambiguates). Consumers
 read `baseUrl` and `services` and never need to care about the flavor.
+
+`browser` is the provider-neutral automation contract. New writers always emit
+it. `playwright` is a legacy compatibility object: emit it as well when the
+selected provider is Playwright, and preserve it when repairing an older
+descriptor. Consumers resolve the provider in this order: `browser.provider`,
+then a present `playwright.runner`, then the config's `browser.provider`, then
+legacy Playwright. `testRunner` describes the repository's committed E2E suite;
+it is independent of the agent-driven browser provider.
 
 Never put real secrets, production credentials, or tokens in the descriptor —
 only disposable/demo values. The descriptor is committed-adjacent working state,

--- a/skills/om-prepare-test-env/references/env-descriptor.md
+++ b/skills/om-prepare-test-env/references/env-descriptor.md
@@ -34,7 +34,6 @@ always attach to the same instance:
     "notes": ""
   },
   "testRunner": { "name": "playwright | cypress | wdio | other | none", "config": "<path or empty>" },
-  "playwright": { "runner": "playwright", "installed": true, "config": ".ai/qa/playwright.config.ts", "browsers": ["chromium"] },
   "platform": "linux | darwin | wsl2 | win32",
   "startedAt": "<ISO-8601 UTC>",
   "notes": "<anything a consumer must know: teardown, seeded data, gotchas, the working preparation chain>"
@@ -50,7 +49,8 @@ read `baseUrl` and `services` and never need to care about the flavor.
 `browser` is the provider-neutral automation contract. New writers always emit
 it. `playwright` is a legacy compatibility object: emit it as well when the
 selected provider is Playwright, and preserve it when repairing an older
-descriptor. Consumers resolve the provider in this order: `browser.provider`,
+descriptor. Its shape remains `{ "runner": "playwright", "installed": true,
+"config": "<path>", "browsers": ["chromium"] }`. Consumers resolve the provider in this order: `browser.provider`,
 then a present `playwright.runner`, then the config's `browser.provider`, then
 legacy Playwright. `testRunner` describes the repository's committed E2E suite;
 it is independent of the agent-driven browser provider.

--- a/skills/om-prepare-test-env/references/phase-2-generate.md
+++ b/skills/om-prepare-test-env/references/phase-2-generate.md
@@ -124,25 +124,39 @@ agent needed to run them, parameterized so a
 human can read and tweak them. Write them with LF line endings and add the
 `.gitattributes` rules from 2.1 in the same change.
 
-### 2.4 Ensure a browser test runner (generation-time, Playwright by default)
+### 2.4 Ensure the configured browser provider (generation-time)
 
-Unless `--playwright off`:
+Unless `--browser off`, resolve `BROWSER_PROVIDER` and `BROWSER_FILE` from the
+config-loading step (or the `--browser-provider` override):
 
-1. If the repo already has a browser test runner (`playwright.config.*`,
-   `cypress.config.*`, `wdio.conf.*`, or equivalent), use it as-is and record
-   which one in the descriptor — do not install a second one.
-2. Otherwise install Playwright with the repo's package manager, verify the
-   binary runs (`npx playwright --version`) and at least one browser is present
-   (`npx playwright install --with-deps chromium`, falling back to
-   `npx playwright install chromium`). Write a minimal shared config at
-   `$QA_DIR/playwright.config.ts` that reads `process.env.BASE_URL` — timeouts
-   and retries live in this shared config, never in individual specs.
-3. Where browsers cannot be installed, do not fail the run: record
-   `playwright.installed: false` with the blocker in `notes` so consumers can
-   still run API-level checks and report the limitation honestly.
+1. If the provider was explicit and `$BROWSER_FILE` is missing, run
+   `om-setup-agent-pipeline` to install the selected descriptor, reload, and
+   continue. For a config created before browser descriptors existed, the
+   implicit Playwright provider may use the legacy Playwright flow below.
+2. Read `$BROWSER_FILE`; execute its **ensure-installed** operation, then its
+   **doctor** operation. The provider owns platform detection, autonomous CLI
+   and browser-engine installation, and live-launch verification. The agent runs
+   those operations itself — never hand prerequisite commands to the operator.
+3. Independently discover any repository-native committed test runner
+   (`playwright.config.*`, `cypress.config.*`, `wdio.conf.*`, or equivalent) and
+   record it as `testRunner`. Selecting agent-browser for exploration and
+   screenshots never replaces an existing suite.
+4. Record the provider operation outputs in the descriptor's `browser` object:
+   provider, installed, command, version, descriptor path, and notes. When the
+   provider is Playwright, also write the legacy `playwright` object so older
+   consumers keep working.
+5. Where installation or **doctor** fails after the descriptor exhausts its
+   autonomous paths, do not fail the app boot: record `browser.installed: false`
+   and the concrete blocker in `notes` so consumers can still run API checks and
+   report the browser limitation honestly.
 
-This runs once, here — the generated script only *records* the runner state in
-the descriptor; it never re-installs browsers on the fast path.
+Legacy Playwright fallback: use the repository's existing Playwright setup when
+present. Otherwise install it with the package manager selected by the lockfile,
+install Chromium and available OS dependencies, and write a minimal shared
+config at `$QA_DIR/playwright.config.ts` reading `process.env.BASE_URL`.
+
+Provider provisioning runs once here. The generated entrypoint records the
+verified state on warm runs; it never reinstalls a healthy provider.
 
 ### 2.5 Verify the script — cold and warm
 

--- a/skills/om-prepare-test-env/references/phase-2-generate.md
+++ b/skills/om-prepare-test-env/references/phase-2-generate.md
@@ -129,6 +129,9 @@ human can read and tweak them. Write them with LF line endings and add the
 Unless `--browser off`, resolve `BROWSER_PROVIDER` and `BROWSER_FILE` from the
 config-loading step (or the `--browser-provider` override):
 
+Validate the final provider name against `^[A-Za-z0-9._-]+$` before
+interpolating it into `.ai/browsers/<provider>.md`; reject any other value.
+
 1. If the provider was explicit and `$BROWSER_FILE` is missing, run
    `om-setup-agent-pipeline` to install the selected descriptor, reload, and
    continue. For a config created before browser descriptors existed, the

--- a/skills/om-setup-agent-pipeline/SKILL.md
+++ b/skills/om-setup-agent-pipeline/SKILL.md
@@ -217,6 +217,9 @@ SPECS_DIR=$(jq -r '.paths.specs // ".ai/specs"' "$CONFIG")
 SCRIPTS_DIR=$(jq -r '.paths.scripts // ".ai/scripts"' "$CONFIG")
 QA_DIR=$(jq -r '.paths.qa // ".ai/qa"' "$CONFIG")
 BROWSER_PROVIDER=$(jq -r '.browser.provider // "playwright"' "$CONFIG")
+case "$BROWSER_PROVIDER" in
+  ''|*[!A-Za-z0-9._-]*) echo "Invalid browser.provider: $BROWSER_PROVIDER" >&2; exit 1 ;;
+esac
 BROWSER_FILE=".ai/browsers/${BROWSER_PROVIDER}.md"
 ```
 

--- a/skills/om-setup-agent-pipeline/SKILL.md
+++ b/skills/om-setup-agent-pipeline/SKILL.md
@@ -20,6 +20,7 @@ Every skill in this collection reads its repository-specific settings from `.ai/
   "version": 1,
   "baseBranch": "auto",
   "tracker": "github",
+  "browser": { "provider": "agent-browser" },
   "validation": {
     "commands": ["pnpm typecheck", "pnpm test", "pnpm build"]
   },
@@ -47,6 +48,7 @@ Field reference:
 
 - `baseBranch` — the branch PRs target. `"auto"` means: resolve at runtime from the repository's default branch (see the loading snippet below). Set an explicit name only when PRs must target something other than the default branch.
 - `tracker` — the issue/PR tracker provider. Selects the tracker descriptor at `.ai/trackers/<tracker>.md`, which defines how every tracker operation the skills name is executed. The collection ships `"github"` (the `gh` CLI); other trackers are added by writing one descriptor file — see Tracker providers below.
+- `browser.provider` — the browser-automation provider used by QA and integration-test skills. Selects `.ai/browsers/<provider>.md`. Fresh setups default to `"agent-browser"`; existing configs without this key retain the legacy Playwright behavior until upgraded. See Browser providers below.
 - `validation.commands` — ordered list of shell commands that constitute the full validation gate. Skills run them in order and treat any non-zero exit as a gate failure. Keep the list complete: typecheck, lint, tests, build — whatever proves the repo is healthy.
 - `labels.enabled` — when `false`, skills skip every label operation and note that in their PR summaries. Use this for repos that do not want the label workflow.
 - `labels.pipeline` — mutually exclusive workflow states. A PR carries at most one.
@@ -69,6 +71,26 @@ No skill in this collection calls a tracker CLI or API directly. Skills name **t
 The repo's copy is authoritative, which is also the extension mechanism: teams edit `.ai/trackers/<tracker>.md` to extend or override any operation — extra flags, a different command, added conventions — and every skill picks the change up on its next run without touching the installed skills. A whole new tracker (for example Linear) is ONE new descriptor file written from `TEMPLATE.md`, plus the matching `tracker` value; split setups (issues in Linear, PRs on GitHub) implement the issue operations against the issue tracker and delegate the PR sections to the GitHub descriptor, as the template describes.
 
 The collection ships `github.md`. For a `tracker` value with no shipped descriptor and no existing `.ai/trackers/<tracker>.md`, scaffold the repo file from `references/trackers/TEMPLATE.md`, tell the user to fill in the operations, and stop — skills must not run against an unfilled descriptor.
+
+## Browser providers
+
+Browser-capable skills use the same committed-descriptor pattern as trackers.
+They name provider operations — **ensure-installed**, **doctor**, **open**,
+**snapshot**, **interact**, **assert**, **screenshot**, and **close** — and read
+`.ai/browsers/<provider>.md`, selected by `browser.provider`. The repo's copy is
+authoritative and may extend the shipped operations without editing installed
+skills.
+
+This collection ships `agent-browser.md` and `playwright.md`, plus
+`references/browsers/TEMPLATE.md` for custom providers. `agent-browser` is the
+fresh-setup default and self-provisions its native CLI, Chrome for Testing, and
+available OS libraries on macOS, Linux, WSL2, Git Bash, and native Windows. It
+uses local browser processes only — no cloud-browser account or API key.
+
+Backward compatibility is deliberate: a config without `browser.provider` is
+read as `playwright`, and browser consumers accept the legacy `playwright`
+object in `test-env.json`. Re-run this setup skill or `om-apply-upgrade-notes`
+to make the choice explicit and install a browser descriptor.
 
 ## Project docs: SDLC.md, AGENTS.md, CODE_REVIEW.md, BACKWARD_COMPATIBILITY.md
 
@@ -108,11 +130,15 @@ List what CI already runs (`.github/workflows/*.yml`) and prefer commands that m
 
 1. Confirm or edit the detected validation commands.
 2. Which tracker provider to install (default: `github`). This sets the config's `tracker` field and which descriptor lands in `.ai/trackers/`.
-3. Labels: install the full taxonomy above (recommended), keep a subset, or disable labels entirely.
-4. QA gate on or off. Recommend on when the repo ships user-facing changes.
-5. Where specs live (`paths.specs`, default `.ai/specs`) — confirm or point at an existing design-doc directory.
-6. Optional repo-local review checklist path.
-7. Project docs to generate (each only when missing): `SDLC.md` (recommended), `AGENTS.md` with the task-routing table (when no agent instruction file exists), `CODE_REVIEW.md`, and `BACKWARD_COMPATIBILITY.md`.
+3. Which browser provider to install (default: `agent-browser`; `playwright` is
+   the compatibility choice). Explain that the selected descriptor owns
+   autonomous CLI/browser provisioning and that repository-native E2E suites
+   remain authoritative.
+4. Labels: install the full taxonomy above (recommended), keep a subset, or disable labels entirely.
+5. QA gate on or off. Recommend on when the repo ships user-facing changes.
+6. Where specs live (`paths.specs`, default `.ai/specs`) — confirm or point at an existing design-doc directory.
+7. Optional repo-local review checklist path.
+8. Project docs to generate (each only when missing): `SDLC.md` (recommended), `AGENTS.md` with the task-routing table (when no agent instruction file exists), `CODE_REVIEW.md`, and `BACKWARD_COMPATIBILITY.md`.
 
 ### 4. Install the tracker descriptor
 
@@ -121,13 +147,25 @@ Copy the shipped descriptor for the chosen tracker from this skill's `references
 - When `.ai/trackers/<tracker>.md` already exists, never overwrite it silently — the team may have extended it. Show a diff against the shipped version and ask whether to refresh, merge, or keep.
 - When the chosen tracker has no shipped descriptor, scaffold `.ai/trackers/<tracker>.md` from `references/trackers/TEMPLATE.md` and tell the user which operations they must fill in before the other skills can run.
 
-### 5. Create missing labels
+### 5. Install the browser descriptor
+
+Install the selected browser descriptor by copying
+`references/browsers/<provider>.md` to `.ai/browsers/<provider>.md`. When the
+repo copy already exists, apply the same protection as tracker descriptors:
+show the operation-section diff and ask whether to refresh, merge, or keep. For
+an unshipped provider, scaffold from `references/browsers/TEMPLATE.md`, report
+the operations that must be implemented, and stop browser-capable work until
+the descriptor is filled. Existing configs without `browser.provider` keep
+legacy Playwright behavior; do not create a descriptor unless setup is being
+re-run to upgrade the repo.
+
+### 6. Create missing labels
 
 When labels are enabled, list existing labels via the tracker **list-labels** operation and offer to create the missing ones via **ensure-label-taxonomy** (both defined in the installed descriptor, which also carries the recommended colors and descriptions).
 
 Skip creation for labels that already exist. Never delete or recolor existing labels without being asked.
 
-### 6. Generate the project docs
+### 7. Generate the project docs
 
 Per the Project docs section above, generate every doc the user opted into — each only when it does not already exist:
 
@@ -138,20 +176,20 @@ Per the Project docs section above, generate every doc the user opted into — e
 
 Show each generated document to the user before writing. Never overwrite an existing process doc or agent instruction file — when one exists, skip it and note that the skills will use the existing file as-is.
 
-### 7. Write and commit the config
+### 8. Write and commit the config
 
 Write `.ai/agentic.config.json`, create the `paths.runs`, `paths.analysis`, `paths.specs`, `paths.scripts`, and `paths.qa` directories with a `.gitkeep` each, show the final file to the user, and offer to commit. Add `<paths.qa>/artifacts_*/` and the running-state descriptor `<paths.qa>/test-env.json` to `.gitignore` (generated per run, not source), while keeping the generated `<paths.scripts>/` launchers committed so the environment is reproducible:
 
 ```bash
-git add .ai/agentic.config.json .ai/trackers/ .ai/runs/.gitkeep .ai/analysis/.gitkeep .ai/specs/.gitkeep .ai/scripts/.gitkeep .ai/qa/.gitkeep SDLC.md
+git add .ai/agentic.config.json .ai/trackers/ .ai/browsers/ .ai/runs/.gitkeep .ai/analysis/.gitkeep .ai/specs/.gitkeep .ai/scripts/.gitkeep .ai/qa/.gitkeep SDLC.md
 git commit -m "chore: configure agent PR pipeline"
 ```
 
 Include `AGENTS.md`, `CODE_REVIEW.md`, and `BACKWARD_COMPATIBILITY.md` in the commit when they were generated this run.
 
-### 8. Report
+### 9. Report
 
-Tell the user which skills are now unlocked and that the collection's entry points are `om-auto-create-pr` (ship a task as a PR), `om-auto-review-pr` (review a PR), and `om-merge-buddy` (what can merge now). Point at `SDLC.md` as the process reference for humans, at repo-local skills under `.ai/skills/<skill-name>/` as the way to customize any single skill, and at `.ai/trackers/<tracker>.md` as the way to customize tracker operations.
+Tell the user which skills are now unlocked and that the collection's entry points are `om-auto-create-pr` (ship a task as a PR), `om-auto-review-pr` (review a PR), and `om-merge-buddy` (what can merge now). Point at `SDLC.md` as the process reference for humans, at repo-local skills under `.ai/skills/<skill-name>/` as the way to customize any single skill, at `.ai/trackers/<tracker>.md` as the way to customize tracker operations, and at `.ai/browsers/<provider>.md` as the browser automation/provisioning contract.
 
 ## The standard config-loading snippet
 
@@ -178,6 +216,8 @@ QA_GATE=$(jq -r '.qaGate // false' "$CONFIG")
 SPECS_DIR=$(jq -r '.paths.specs // ".ai/specs"' "$CONFIG")
 SCRIPTS_DIR=$(jq -r '.paths.scripts // ".ai/scripts"' "$CONFIG")
 QA_DIR=$(jq -r '.paths.qa // ".ai/qa"' "$CONFIG")
+BROWSER_PROVIDER=$(jq -r '.browser.provider // "playwright"' "$CONFIG")
+BROWSER_FILE=".ai/browsers/${BROWSER_PROVIDER}.md"
 ```
 
 When the snippet reports a missing config or tracker descriptor, the calling skill does not stop and bounce the user — it runs this skill (`om-setup-agent-pipeline`) itself: interactively when a user is present to answer the questions, with `--defaults` when running unattended (autonomous loops, headless runs). Setup runs in the repository's primary checkout; if the calling skill already created an isolated worktree, copy the generated `.ai/` files (and any generated docs) into that worktree before continuing. Once setup has written the config and installed the tracker descriptor, the calling skill re-runs the snippet and continues from the step it was on. The calling skill stops only when the user declines setup or setup itself fails.
@@ -188,6 +228,13 @@ Right after loading the config, a skill:
 2. Reads the tracker descriptor at `$TRACKER_FILE`. Every **tracker operation** the skill names (**get-issue**, **create-pr**, **comment-pr**, …) is executed as that file defines it, and the label guards (`label_exists`, `apply_label`, `apply_issue_label`, `remove_issue_label`, `set_pipeline_label`) are the ones the descriptor defines — a label mutation outside those guards is a bug. When `BASE_BRANCH` is `auto`, resolve it now via the descriptor's **default-branch** operation.
 3. Reads the repository's agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) for project specifics before doing any work — plus, when present at the repo root, `CODE_REVIEW.md` (review skills) and `BACKWARD_COMPATIBILITY.md` (review and implementation skills; implementation skills must warn the user when a change is not compliant with it).
 
+Browser-capable skills additionally read `$BROWSER_FILE` and execute its named
+operations. For compatibility with repositories configured before browser
+descriptors existed, only the implicit `playwright` provider may use the
+installed skill's legacy Playwright instructions when that file is absent. An
+explicit provider with a missing descriptor triggers this setup skill to install
+it; never improvise provider commands.
+
 ## Rules
 
 - Never write the config without showing the user what was detected, unless `--defaults` was passed.
@@ -197,3 +244,4 @@ Right after loading the config, a skill:
 - Never store secrets, tokens, or user identities in the config file.
 - Keep the config committed; it is team configuration, not personal preference.
 - A `tracker` value with no shipped descriptor and no filled-in `.ai/trackers/<tracker>.md` is an error — scaffold from the template, say so, and stop; do not improvise tracker calls.
+- An explicit `browser.provider` with no shipped descriptor and no filled-in `.ai/browsers/<provider>.md` is an error for browser-capable skills — scaffold from the browser template, say so, and stop; do not improvise browser calls.

--- a/skills/om-setup-agent-pipeline/references/browsers/TEMPLATE.md
+++ b/skills/om-setup-agent-pipeline/references/browsers/TEMPLATE.md
@@ -1,0 +1,81 @@
+# Browser provider: <name>
+
+This descriptor implements the browser-automation operations used by
+`om-prepare-test-env`, `om-auto-verify-pr-ui`, and `om-integration-tests`. The
+config's `browser.provider` value selects the committed copy at
+`.ai/browsers/<name>.md`.
+
+## Contract
+
+A provider descriptor MUST define every operation below. Commands may differ by
+platform, but the observable behavior and output stay the same.
+
+### ensure-installed
+
+Inputs: `QA_DIR`, current platform, and architecture. Install the provider and
+its local browser engine without asking the operator to preinstall a runtime,
+package manager, browser, or OS library. Reuse a healthy installation. On Linux,
+attempt required system-library installation non-interactively when the agent
+already has root or passwordless elevation. Never silently fall back to a cloud
+browser or request third-party credentials.
+
+Output these machine-readable lines:
+
+```text
+BROWSER_PROVIDER=<name>
+BROWSER_INSTALLED=0|1
+BROWSER_COMMAND=<absolute command path or repository runner command>
+BROWSER_VERSION=<version or unknown>
+BROWSER_NOTES=<empty or concrete blocker>
+```
+
+Unsupported OS/CPU combinations and exhausted privilege failures are explicit
+blockers. Never report installed until the live-launch check passes.
+
+### doctor
+
+Run the provider's non-destructive health check, including a real headless
+browser launch. Return non-zero when navigation and screenshots would fail.
+
+### open
+
+Input: `BASE_URL` or a validated URL. Open it in an isolated session scoped to
+the current run. Output enough state for later operations to address the same
+session.
+
+### snapshot
+
+Return an accessibility/interactive snapshot with stable element references.
+The executing agent uses only references observed here; it never guesses
+selectors.
+
+### interact
+
+Input: one observed element reference plus an action (`click`, `fill`, keyboard
+input, select, or equivalent). Execute the action and return non-zero on failure.
+Re-snapshot after navigation or material DOM changes.
+
+### assert
+
+Input: an observed condition such as visible text, URL, element state, or value.
+Return zero only when the condition is observed. Include the observed value in
+output so reports are evidence-backed.
+
+### screenshot
+
+Input: an output PNG path, optionally full-page. Write the screenshot exactly at
+that path and return non-zero when capture fails.
+
+### close
+
+Close only the session created by **open**. Safe to call more than once.
+
+## Rules
+
+- Keep installation agent-owned and local. Never require the operator to run a
+  prerequisite command or subscribe to a remote browser service.
+- Keep sessions isolated per run and close them in `trap`/`finally` cleanup.
+- Never put real credentials in commands, snapshots, screenshots, or logs.
+- A repository-native committed E2E runner remains authoritative. This provider
+  owns agent-driven exploration, assertions, and evidence capture; it does not
+  replace an existing suite merely because it was selected.

--- a/skills/om-setup-agent-pipeline/references/browsers/TEMPLATE.md
+++ b/skills/om-setup-agent-pipeline/references/browsers/TEMPLATE.md
@@ -29,6 +29,10 @@ BROWSER_VERSION=<version or unknown>
 BROWSER_NOTES=<empty or concrete blocker>
 ```
 
+Consumers parse everything after the first `=` as the value; they never source
+these lines as shell code. This preserves Windows command paths containing
+spaces.
+
 Unsupported OS/CPU combinations and exhausted privilege failures are explicit
 blockers. Never report installed until the live-launch check passes.
 

--- a/skills/om-setup-agent-pipeline/references/browsers/agent-browser.md
+++ b/skills/om-setup-agent-pipeline/references/browsers/agent-browser.md
@@ -51,8 +51,8 @@ else
   if [ ! -x "$AGENT_BROWSER_BIN" ]; then
     URL="https://github.com/vercel-labs/agent-browser/releases/latest/download/$ASSET"
     TMP="$AGENT_BROWSER_BIN.tmp.$$"
-    if command -v curl >/dev/null 2>&1; then curl -fL --retry 3 -o "$TMP" "$URL"
-    elif command -v wget >/dev/null 2>&1; then wget -O "$TMP" "$URL"
+    if command -v curl >/dev/null 2>&1; then curl -fL --retry 3 --connect-timeout 30 --max-time 600 -o "$TMP" "$URL"
+    elif command -v wget >/dev/null 2>&1; then wget -T 30 -t 3 -O "$TMP" "$URL"
     else echo "No built-in HTTP downloader is available" >&2; exit 1
     fi
     chmod 755 "$TMP"
@@ -93,7 +93,10 @@ else {
   if (-not (Test-Path $AgentBrowser)) {
     $url = 'https://github.com/vercel-labs/agent-browser/releases/latest/download/agent-browser-win32-x64.exe'
     $tmp = "$AgentBrowser.tmp.$PID"
-    Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $tmp
+    if ($PSVersionTable.PSVersion.Major -lt 7) {
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    }
+    Invoke-WebRequest -UseBasicParsing -TimeoutSec 600 -Uri $url -OutFile $tmp
     Move-Item -Force $tmp $AgentBrowser
   }
 }

--- a/skills/om-setup-agent-pipeline/references/browsers/agent-browser.md
+++ b/skills/om-setup-agent-pipeline/references/browsers/agent-browser.md
@@ -155,11 +155,17 @@ Use JSON output and compare the observed value in the current shell. Examples:
 ### screenshot
 
 ```bash
-"$AGENT_BROWSER_BIN" --session "$BROWSER_SESSION" screenshot "$SCREENSHOT_PATH" --full --json
-test -s "$SCREENSHOT_PATH"
+SCREENSHOT_DIR=$(dirname "$SCREENSHOT_PATH")
+mkdir -p "$SCREENSHOT_DIR"
+ABS_SCREENSHOT_PATH=$(cd "$SCREENSHOT_DIR" && pwd)/$(basename "$SCREENSHOT_PATH")
+"$AGENT_BROWSER_BIN" --session "$BROWSER_SESSION" screenshot --full "$ABS_SCREENSHOT_PATH" --json
+test -s "$ABS_SCREENSHOT_PATH"
 ```
 
-PowerShell checks `Test-Path $ScreenshotPath` and a non-zero file length.
+The absolute path avoids the CLI treating a relative multi-segment path as a
+selector. PowerShell resolves it with
+`[IO.Path]::GetFullPath($ScreenshotPath)`, creates the parent directory, then
+checks `Test-Path` and a non-zero file length.
 
 ### close
 

--- a/skills/om-setup-agent-pipeline/references/browsers/agent-browser.md
+++ b/skills/om-setup-agent-pipeline/references/browsers/agent-browser.md
@@ -1,0 +1,180 @@
+# Browser provider: agent-browser
+
+This is the local, self-provisioning `agent-browser` implementation of the
+browser-provider contract in `TEMPLATE.md`. It uses native release binaries and
+Chrome for Testing. It never requires Node, a project package manager, a
+preinstalled browser, or a cloud-browser account.
+
+## Prerequisites
+
+- Network access to GitHub Releases and the Chrome-for-Testing download host on
+  first install. Warm runs reuse the cached binary and browser.
+- Supported release targets: macOS x64/arm64; Linux glibc or musl x64/arm64;
+  Windows x64. WSL2 uses the matching Linux target. Windows on ARM may use the
+  x64 binary only when the operating system's x64 compatibility layer is active.
+- Linux Chrome libraries may require root. The operation below performs the
+  install itself when already root or passwordless elevation is available; it
+  never delegates commands to the operator.
+
+## Operations
+
+### ensure-installed
+
+Use an existing healthy `agent-browser` from `PATH`; otherwise install the
+official native release in a per-user cache. Do not add binary files to the
+repository.
+
+POSIX shell (macOS, Linux, WSL2, Git Bash/MSYS):
+
+```bash
+if command -v agent-browser >/dev/null 2>&1; then
+  AGENT_BROWSER_BIN=$(command -v agent-browser)
+else
+  CACHE_ROOT=${XDG_CACHE_HOME:-"$HOME/.cache"}
+  TOOL_DIR="$CACHE_ROOT/agent-tools/agent-browser"
+  mkdir -p "$TOOL_DIR"
+  OS=$(uname -s 2>/dev/null || echo unknown)
+  ARCH=$(uname -m 2>/dev/null || echo unknown)
+  case "$ARCH" in x86_64|amd64) ARCH=x64 ;; arm64|aarch64) ARCH=arm64 ;; *) ARCH=unsupported ;; esac
+  case "$OS" in
+    Darwin) ASSET="agent-browser-darwin-$ARCH" ;;
+    Linux)
+      LIBC=linux
+      (ldd --version 2>&1 || true) | grep -qi musl && LIBC=linux-musl
+      ASSET="agent-browser-$LIBC-$ARCH"
+      ;;
+    MINGW*|MSYS*|CYGWIN*) ASSET=agent-browser-win32-x64.exe ;;
+    *) ASSET=unsupported ;;
+  esac
+  case "$ASSET" in *unsupported*) echo "Unsupported agent-browser target: $OS/$ARCH" >&2; exit 1 ;; esac
+  AGENT_BROWSER_BIN="$TOOL_DIR/$ASSET"
+  if [ ! -x "$AGENT_BROWSER_BIN" ]; then
+    URL="https://github.com/vercel-labs/agent-browser/releases/latest/download/$ASSET"
+    TMP="$AGENT_BROWSER_BIN.tmp.$$"
+    if command -v curl >/dev/null 2>&1; then curl -fL --retry 3 -o "$TMP" "$URL"
+    elif command -v wget >/dev/null 2>&1; then wget -O "$TMP" "$URL"
+    else echo "No built-in HTTP downloader is available" >&2; exit 1
+    fi
+    chmod 755 "$TMP"
+    mv "$TMP" "$AGENT_BROWSER_BIN"
+  fi
+fi
+
+"$AGENT_BROWSER_BIN" install
+if ! "$AGENT_BROWSER_BIN" doctor --json >/dev/null 2>&1; then
+  if [ "$(uname -s 2>/dev/null || true)" = Linux ]; then
+    if [ "$(id -u)" = 0 ]; then
+      "$AGENT_BROWSER_BIN" install --with-deps
+    elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+      sudo -n "$AGENT_BROWSER_BIN" install --with-deps
+    fi
+  fi
+fi
+if "$AGENT_BROWSER_BIN" doctor --json >/dev/null; then
+  printf 'BROWSER_PROVIDER=agent-browser\nBROWSER_INSTALLED=1\nBROWSER_COMMAND=%s\nBROWSER_VERSION=%s\nBROWSER_NOTES=\n' \
+    "$AGENT_BROWSER_BIN" "$("$AGENT_BROWSER_BIN" --version 2>/dev/null || echo unknown)"
+else
+  printf 'BROWSER_PROVIDER=agent-browser\nBROWSER_INSTALLED=0\nBROWSER_COMMAND=%s\nBROWSER_VERSION=unknown\nBROWSER_NOTES=live browser launch failed after autonomous install\n' "$AGENT_BROWSER_BIN"
+  exit 1
+fi
+```
+
+Native Windows PowerShell:
+
+```powershell
+$onPath = Get-Command agent-browser -ErrorAction SilentlyContinue
+if ($onPath) { $AgentBrowser = $onPath.Source }
+else {
+  $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+  if ($arch -notin 'X64','Arm64') { throw "Unsupported agent-browser Windows architecture: $arch" }
+  $toolDir = Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'agent-tools/agent-browser'
+  New-Item -ItemType Directory -Force -Path $toolDir | Out-Null
+  $AgentBrowser = Join-Path $toolDir 'agent-browser-win32-x64.exe'
+  if (-not (Test-Path $AgentBrowser)) {
+    $url = 'https://github.com/vercel-labs/agent-browser/releases/latest/download/agent-browser-win32-x64.exe'
+    $tmp = "$AgentBrowser.tmp.$PID"
+    Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $tmp
+    Move-Item -Force $tmp $AgentBrowser
+  }
+}
+& $AgentBrowser install
+& $AgentBrowser doctor --json | Out-Null
+if ($LASTEXITCODE -ne 0) { throw 'agent-browser live browser launch failed after autonomous install' }
+$version = (& $AgentBrowser --version 2>$null)
+"BROWSER_PROVIDER=agent-browser"
+"BROWSER_INSTALLED=1"
+"BROWSER_COMMAND=$AgentBrowser"
+"BROWSER_VERSION=$version"
+"BROWSER_NOTES="
+```
+
+### doctor
+
+```bash
+"$AGENT_BROWSER_BIN" doctor --json
+```
+
+PowerShell: `& $AgentBrowser doctor --json`.
+
+### open
+
+Use a unique, validated session id such as `qa-<runId>`:
+
+```bash
+"$AGENT_BROWSER_BIN" --session "$BROWSER_SESSION" open "$BASE_URL" --json
+```
+
+### snapshot
+
+```bash
+"$AGENT_BROWSER_BIN" --session "$BROWSER_SESSION" snapshot -i --json
+```
+
+### interact
+
+Use only a ref returned by the latest snapshot:
+
+```bash
+"$AGENT_BROWSER_BIN" --session "$BROWSER_SESSION" click "$ELEMENT_REF" --json
+"$AGENT_BROWSER_BIN" --session "$BROWSER_SESSION" fill "$ELEMENT_REF" "$VALUE" --json
+```
+
+Other actions use the matching CLI command shown by
+`"$AGENT_BROWSER_BIN" --help`; never interpolate untrusted shell fragments.
+
+### assert
+
+Use JSON output and compare the observed value in the current shell. Examples:
+
+```bash
+"$AGENT_BROWSER_BIN" --session "$BROWSER_SESSION" get text "$ELEMENT_REF" --json
+"$AGENT_BROWSER_BIN" --session "$BROWSER_SESSION" get url --json
+"$AGENT_BROWSER_BIN" --session "$BROWSER_SESSION" is visible "$ELEMENT_REF" --json
+```
+
+### screenshot
+
+```bash
+"$AGENT_BROWSER_BIN" --session "$BROWSER_SESSION" screenshot "$SCREENSHOT_PATH" --full --json
+test -s "$SCREENSHOT_PATH"
+```
+
+PowerShell checks `Test-Path $ScreenshotPath` and a non-zero file length.
+
+### close
+
+```bash
+"$AGENT_BROWSER_BIN" --session "$BROWSER_SESSION" close --json 2>/dev/null || true
+```
+
+In PowerShell, run the same arguments with `& $AgentBrowser` in `finally` and
+ignore only an already-closed-session error.
+
+## Rules
+
+- Run `agent-browser skills get core` when available before a complex scenario
+  so interaction guidance matches the installed CLI version.
+- Use a unique session per QA/test run. Never attach to a user's normal browser
+  profile unless the operator explicitly requested that profile.
+- Keep all operation targets local to the application under test. Do not enable
+  a cloud provider or send credentials to a remote browser service.

--- a/skills/om-setup-agent-pipeline/references/browsers/playwright.md
+++ b/skills/om-setup-agent-pipeline/references/browsers/playwright.md
@@ -1,0 +1,73 @@
+# Browser provider: playwright
+
+This is the compatibility provider for repositories that use Playwright for
+agent-driven browser exploration and evidence capture.
+
+## Operations
+
+### ensure-installed
+
+If the repository already has `@playwright/test` or a `playwright.config.*`, use
+its package runner and config. Otherwise install Playwright as a development
+dependency with the package manager selected by the repository's lockfile, then
+run its browser installer for Chromium with OS dependencies. On Linux, retry the
+dependency install only when root or passwordless elevation is already
+available; do not ask the operator to perform the install.
+
+Write a minimal shared config at `<paths.qa>/playwright.config.ts` when the repo
+has none. It reads `process.env.BASE_URL`; timeouts and retries live in that
+shared config.
+
+Output:
+
+```text
+BROWSER_PROVIDER=playwright
+BROWSER_INSTALLED=0|1
+BROWSER_COMMAND=<repository package-runner command>
+BROWSER_VERSION=<version or unknown>
+BROWSER_NOTES=<empty or concrete blocker>
+```
+
+### doctor
+
+Run the repository package runner's Playwright version command, then launch a
+one-page Chromium smoke test against a local `data:` URL. Return non-zero when
+the browser cannot launch.
+
+### open
+
+Use Playwright's configured Chromium project and a throwaway spec outside the
+repository's discovered test directories. Navigate to the validated `BASE_URL`.
+
+### snapshot
+
+Use the live page's accessibility tree or role/label queries. Record exact
+roles, labels, text, and element states before interacting.
+
+### interact
+
+Use only role/label/text locators observed by **snapshot**. Do not guess CSS
+paths. Re-observe after navigation or material DOM changes.
+
+### assert
+
+Use Playwright web-first assertions in the throwaway spec. Return non-zero on a
+failed condition and preserve the error context artifact.
+
+### screenshot
+
+Call `page.screenshot({ path: SCREENSHOT_PATH, fullPage: true })`, then verify
+the PNG exists and is non-empty.
+
+### close
+
+Close the throwaway page, context, and browser in `finally`. Safe to repeat.
+
+## Rules
+
+- Use the repository's package manager and existing runner configuration; never
+  add a second Playwright installation.
+- Keep throwaway exploration specs under the QA artifacts directory, never in a
+  discovered test directory.
+- Repository-native committed tests remain authoritative and run with the
+  repository's existing command.


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-14-agent-browser-support.md
Status: complete

## Goal
- Add first-class, self-provisioning agent-browser support across pipeline setup, test-environment preparation, UI QA, and integration-test authoring on supported desktop platforms.

## What Changed
- Added `browser.provider` and committed `.ai/browsers/<provider>.md` contracts, with shipped agent-browser and Playwright descriptors.
- Added autonomous native agent-browser/Chrome provisioning for macOS, Linux, WSL2, Git Bash, and native Windows, with platform/architecture validation and live launch diagnostics.
- Added provider-neutral `test-env.json` fields while preserving legacy Playwright readers and repository-native E2E runners.
- Updated setup, upgrade migration, UI QA, integration testing, compatibility docs, decisions, and README guidance.
- Added a 10-target contract matrix and a Codex CLI E2E harness exercising `om-prepare-test-env`, `om-auto-verify-pr-ui`, and `om-integration-tests` against a local fixture.

## Tests
- `bash scripts/lint.sh`
- `node scripts/test-browser-providers.mjs`
- `KEEP_CODEX_E2E_FIXTURE=1 bash scripts/test-agent-browser-codex.sh` on Linux x64 with Codex CLI 0.144.4, agent-browser 0.31.2, and Chrome for Testing 150.0.7871.115
- Focused rerun of the integration-test Codex phase after removing the generated PowerShell launcher’s POSIX dependency
- `git diff --check` and shell syntax validation

## Breaking Changes
- None. New config and environment-descriptor fields are additive; configs without `browser.provider` and descriptors with only the legacy `playwright` object continue using Playwright.

## Progress
See the Progress section in the tracking plan.
