### PR TITLE
refactor(om-gap-analysis): swap fixture scenario to a clearly synthetic domain

### DIFF
--- a/skills/om-gap-analysis/bin/gap-pipeline-crosscheck
+++ b/skills/om-gap-analysis/bin/gap-pipeline-crosscheck
@@ -64,7 +64,7 @@
 #      contributing stem UNIQUE to that one candidate in the snapshot
 #      (df == 1) whose original token carries a capital or digit beyond its
 #      first character — engagement-central acronyms and product names
-#      ("KSeF", "DataTable") are exactly the single-token matches worth
+#      ("ShipSync", "DataTable") are exactly the single-token matches worth
 #      surfacing; snapshot-side uniqueness plus the proper-noun shape is what
 #      mechanically separates them from generic single-token collisions
 #      ("upload", "export") and from title-case ordinary first words, both
@@ -248,7 +248,7 @@ FILENAME == ARGV[1] {
     df[s]++
   }
   # Mark PROPER stems — original token carries a capital or digit BEYOND its
-  # first character ("KSeF", "DataTable", "CrudForm"). These gate the
+  # first character ("ShipSync", "DataTable", "CrudForm"). These gate the
   # single-stem match path below: an internally-cased/numbered token is an
   # acronym or product name, the kind of term worth flagging on alone. The
   # first character is deliberately ignored — real snapshot titles include

--- a/skills/om-gap-analysis/fixtures/README.md
+++ b/skills/om-gap-analysis/fixtures/README.md
@@ -9,7 +9,7 @@ a change that flips any expected code is a regression.
 | `bin/gap-checklist-gate fixtures/gap-checklist/happy-path-only.md` | exit 1 — names the phantom story ref and the reasonless out-of-scope |
 | `bin/gap-checklist-gate fixtures/gap-checklist/no-categories.md` | exit 1 — fail-closed: no `coverage_categories` declared |
 | `bin/gap-checklist-gate` | exit 2 — usage |
-| `bin/gap-pipeline-crosscheck fixtures/gap-crosscheck/tree.md fixtures/gap-crosscheck/snapshot.md` | exit 1 — Story 3.1 missing citation (companion PR #29 via the unique proper-noun stem `ksef`), Story 3.2 phantom (`companion PR #77`) |
+| `bin/gap-pipeline-crosscheck fixtures/gap-crosscheck/tree.md fixtures/gap-crosscheck/snapshot.md` | exit 1 — Story 3.1 missing citation (companion PR #29 via the unique proper-noun stem `shipsync`), Story 3.2 phantom (`companion PR #77`) |
 | `bin/gap-pipeline-crosscheck fixtures/gap-crosscheck/tree-cited.md fixtures/gap-crosscheck/snapshot.md` | exit 0 — both citations resolve |
 | `bin/gap-pipeline-crosscheck fixtures/gap-crosscheck/snapshot.md fixtures/gap-crosscheck/tree.md` | exit 2 — fail-closed on swapped files |
 | `bin/gap-depth-check fixtures/gap-depth/tree.md fixtures/gap-depth/snapshot.md fixtures/gap-depth/summary-fail.md` | exit 1 — companion PR #29 (CHANGES_REQUESTED) unsurfaced |

--- a/skills/om-gap-analysis/fixtures/gap-checklist/complete.md
+++ b/skills/om-gap-analysis/fixtures/gap-checklist/complete.md
@@ -3,7 +3,7 @@ project: fixture-complete
 phase: 1-scoped
 coverage_categories:
   - error-path
-  - nfr-audit
+  - audit-log
 ---
 
 # Gap Analysis — Fixture Complete
@@ -13,7 +13,7 @@ coverage_categories:
 
 #### Coverage
 - error-path: Story 1.2
-- nfr-audit: out-of-scope: client confirmed audit is handled by an external system
+- audit-log: out-of-scope: client confirmed audit is handled by an external system
 
 ### Story 1.1: Book an appointment
 - **Description**: as a customer, I book an appointment

--- a/skills/om-gap-analysis/fixtures/gap-checklist/happy-path-only.md
+++ b/skills/om-gap-analysis/fixtures/gap-checklist/happy-path-only.md
@@ -3,7 +3,7 @@ project: fixture-happy
 phase: 1-scoped
 coverage_categories:
   - error-path
-  - nfr-audit
+  - audit-log
 ---
 
 # Gap Analysis — Fixture Happy Path Only
@@ -13,7 +13,7 @@ coverage_categories:
 
 #### Coverage
 - error-path: Story 1.9
-- nfr-audit: out-of-scope:
+- audit-log: out-of-scope:
 
 ### Story 1.1: Book an appointment
 - **Description**: as a customer, I book an appointment

--- a/skills/om-gap-analysis/fixtures/gap-crosscheck/snapshot.md
+++ b/skills/om-gap-analysis/fixtures/gap-crosscheck/snapshot.md
@@ -1,9 +1,9 @@
 ## Open PRs — platform (acme/platform)
 - PR #12: Fix customer account invitation emails [+120/-14, 6 files, no review yet, updated 2026-07-10T10:00:00Z]
-- PR #15: Improve invoice number formatting for exports [+300/-40, 9 files, no review yet, updated 2026-07-11T10:00:00Z]
+- PR #15: Improve shipment tracking number formatting for exports [+300/-40, 9 files, no review yet, updated 2026-07-11T10:00:00Z]
 
 ## Open PRs — companion (acme/modules)
-- companion PR #29: feat: financial module with full KSeF feature set integration [+60555/-1711, 257 files, CHANGES_REQUESTED, updated 2026-07-12T10:00:00Z]
+- companion PR #29: feat: fulfillment module with full ShipSync carrier integration [+18420/-2103, 134 files, CHANGES_REQUESTED, updated 2026-07-12T10:00:00Z]
 
 ## Planned specs — .ai/specs (platform@integration)
 - 2026-06-01-outbox-pattern.md

--- a/skills/om-gap-analysis/fixtures/gap-crosscheck/tree-cited.md
+++ b/skills/om-gap-analysis/fixtures/gap-crosscheck/tree-cited.md
@@ -7,25 +7,25 @@ coverage_categories:
 
 # Gap Analysis — Fixture Crosscheck
 
-## Epic 3: Invoicing
+## Epic 3: Fulfillment
 
 #### Coverage
 - error-path: Story 3.2
 
-### Story 3.1: Manual KSeF e-invoice export
-- **Description**: as an accountant, I export invoices to KSeF manually
+### Story 3.1: Bulk order sync via ShipSync
+- **Description**: as a warehouse manager, I sync order status via ShipSync
 - **Acceptance criteria**:
-  - [ ] an invoice can be exported to KSeF on demand
+  - [ ] order status can be synced via ShipSync on demand
 - **Status**: done
 
 #### Gap analysis
 - **Verdict**: ❌ Missing
 - **Upstream pipeline**: companion PR #29 (open)
 
-### Story 3.2: Export failure is visible
-- **Description**: as an accountant, I see a failed export with a reason
+### Story 3.2: Sync failure is visible
+- **Description**: as a warehouse manager, I see a failed sync with a reason
 - **Acceptance criteria**:
-  - [ ] a failed export shows an error state
+  - [ ] a failed sync shows an error state
 - **Status**: done
 
 #### Gap analysis

--- a/skills/om-gap-analysis/fixtures/gap-crosscheck/tree.md
+++ b/skills/om-gap-analysis/fixtures/gap-crosscheck/tree.md
@@ -7,25 +7,25 @@ coverage_categories:
 
 # Gap Analysis — Fixture Crosscheck
 
-## Epic 3: Invoicing
+## Epic 3: Fulfillment
 
 #### Coverage
 - error-path: Story 3.2
 
-### Story 3.1: Manual KSeF e-invoice export
-- **Description**: as an accountant, I export invoices to KSeF manually
+### Story 3.1: Bulk order sync via ShipSync
+- **Description**: as a warehouse manager, I sync order status via ShipSync
 - **Acceptance criteria**:
-  - [ ] an invoice can be exported to KSeF on demand
+  - [ ] order status can be synced via ShipSync on demand
 - **Status**: done
 
 #### Gap analysis
 - **Verdict**: ❌ Missing
 - **Upstream pipeline**: none
 
-### Story 3.2: Export failure is visible
-- **Description**: as an accountant, I see a failed export with a reason
+### Story 3.2: Sync failure is visible
+- **Description**: as a warehouse manager, I see a failed sync with a reason
 - **Acceptance criteria**:
-  - [ ] a failed export shows an error state
+  - [ ] a failed sync shows an error state
 - **Status**: done
 
 #### Gap analysis

--- a/skills/om-gap-analysis/fixtures/gap-depth/snapshot.md
+++ b/skills/om-gap-analysis/fixtures/gap-depth/snapshot.md
@@ -1,8 +1,8 @@
 ## Open PRs — platform (acme/platform)
-- PR #15: Improve invoice number formatting for exports [+300/-40, 9 files, no review yet, updated 2026-07-11T10:00:00Z]
+- PR #15: Improve shipment tracking number formatting for exports [+300/-40, 9 files, no review yet, updated 2026-07-11T10:00:00Z]
 
 ## Open PRs — companion (acme/modules)
-- companion PR #29: feat: financial module with full KSeF feature set integration [+60555/-1711, 257 files, CHANGES_REQUESTED, updated 2026-07-12T10:00:00Z]
+- companion PR #29: feat: fulfillment module with full ShipSync carrier integration [+18420/-2103, 134 files, CHANGES_REQUESTED, updated 2026-07-12T10:00:00Z]
 
 ## Planned specs — .ai/specs (platform@integration)
 - 2026-06-01-outbox-pattern.md

--- a/skills/om-gap-analysis/fixtures/gap-depth/summary-fail.md
+++ b/skills/om-gap-analysis/fixtures/gap-depth/summary-fail.md
@@ -1,8 +1,8 @@
 ## Executive summary
-Coverage looks thin in invoicing.
+Coverage looks thin in fulfillment.
 
 ## Top 5 risks
-1. Story 3.1 — KSeF export missing entirely; build from scratch.
+1. Story 3.1 — ShipSync integration missing entirely; build from scratch.
 
 ## Open questions
 None.

--- a/skills/om-gap-analysis/fixtures/gap-depth/summary-pass.md
+++ b/skills/om-gap-analysis/fixtures/gap-depth/summary-pass.md
@@ -1,8 +1,8 @@
 ## Executive summary
-Coverage looks thin in invoicing, but most of the KSeF work already sits in an open companion PR.
+Coverage looks thin in fulfillment, but most of the ShipSync work already sits in an open companion PR.
 
 ## Top 5 risks
-1. Story 3.1 — KSeF export: companion PR #29 (+60555 additions, CHANGES_REQUESTED — reviewer calls it close) already carries the module; adopt-vs-build is the engagement's biggest fork.
+1. Story 3.1 — ShipSync integration: companion PR #29 (+18420 additions, CHANGES_REQUESTED — reviewer calls it close) already carries the module; adopt-vs-build is the engagement's biggest fork.
 
 ## Open questions
 None.

--- a/skills/om-gap-analysis/fixtures/gap-depth/tree.md
+++ b/skills/om-gap-analysis/fixtures/gap-depth/tree.md
@@ -7,23 +7,23 @@ coverage_categories:
 
 # Gap Analysis — Fixture Depth
 
-## Epic 3: Invoicing
+## Epic 3: Fulfillment
 
 #### Coverage
 - error-path: Story 3.1
 
-### Story 3.1: Manual KSeF e-invoice export
-- **Description**: as an accountant, I export invoices to KSeF manually
+### Story 3.1: Bulk order sync via ShipSync
+- **Description**: as a warehouse manager, I sync order status via ShipSync
 - **Acceptance criteria**:
-  - [ ] an invoice can be exported to KSeF on demand
+  - [ ] order status can be synced via ShipSync on demand
 - **Status**: done
 
 #### Gap analysis
 - **Verdict**: ❌ Missing
 - **Upstream pipeline**: companion PR #29 (open)
 
-### Story 3.2: Invoice number formatting
-- **Description**: as an accountant, exported invoice numbers are formatted correctly
+### Story 3.2: Shipment tracking number formatting
+- **Description**: as a warehouse manager, exported tracking numbers are formatted correctly
 - **Acceptance criteria**:
   - [ ] numbers follow the configured format
 - **Status**: done

--- a/skills/om-gap-analysis/references/scoping.md
+++ b/skills/om-gap-analysis/references/scoping.md
@@ -33,12 +33,12 @@ phase: 1-scoped
 total_epics: <n>
 total_stories: <n>
 coverage_categories:
-  - error-path
-  - permission-abuse
-  - concurrency
-  - nfr-multitenancy
-  - nfr-gdpr
-  - nfr-audit
+  - negative-path
+  - abuse-case
+  - race-condition
+  - tenant-isolation
+  - data-privacy
+  - audit-log
 ---
 <!-- coverage_categories is the completeness checklist bin/gap-checklist-gate enforces per epic.
      Extend it per domain when a run needs more (e.g. clinical-data-retention).
@@ -56,12 +56,12 @@ coverage_categories:
 #### Coverage
 <!-- Populated in Phase 1.5; checked by bin/gap-checklist-gate before Phase 2.
      Each category is EITHER a real story ref (`Story <id>`) OR `out-of-scope: <reason>` — never blank. -->
-- error-path: Story 1.2
-- permission-abuse: out-of-scope: <reason the client confirmed>
-- concurrency: Story 1.4
-- nfr-multitenancy: Story 1.3
-- nfr-gdpr: out-of-scope: <reason>
-- nfr-audit: Story 1.5
+- negative-path: Story 1.2
+- abuse-case: out-of-scope: <reason the client confirmed>
+- race-condition: Story 1.4
+- tenant-isolation: Story 1.3
+- data-privacy: out-of-scope: <reason>
+- audit-log: Story 1.5
 
 ### Story 1.1: <Story title>
 - **Description**: <as a [role], I want [capability], so that [outcome]>


### PR DESCRIPTION
## What

Swaps the `om-gap-analysis` gate fixtures (gap-crosscheck, gap-depth) and `scoping.md`'s `coverage_categories` example from a KSeF/invoicing scenario to a fully synthetic fulfillment/shipping one (`ShipSync`).

## Why

The KSeF-themed fixture data read too close to a real engagement trace (specific PR sizes, review state, category taxonomy) rather than an obviously-illustrative example. A synthetic domain exercises the exact same gate paths without that ambiguity — including the acronym-shaped single-token match in `gap-pipeline-crosscheck` (an internally-cased product name plays the same structural role `KSeF` did).

## Verification

Re-ran every assertion in `fixtures/README.md` against the updated fixtures — all expected exit codes still hold:

- `gap-checklist-gate` complete/happy-path-only/no-categories/no-args → 0/1/1/2
- `gap-pipeline-crosscheck` tree/snapshot (missing + phantom citation) → 1, tree-cited/snapshot → 0, swapped files → 2
- `gap-depth-check` fail/pass/min-additions/nonexistent-file → 1/0/1/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)