### PR TITLE
feat(skills): autonomous-by-default Open Questions + PR-management alignment + issue implementation-prep

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -99,6 +99,35 @@ posts the understanding once) and claim-aware (skips issues another actor is
 working), so it is safe to sweep the backlog — default scope is the last ~25 open
 issues, worst-described first, narrowable by state/label/author/limit.
 
+## One PR opener, reused: pr-open-reuse + implement-by-continuation
+
+Several skills open or update PRs, and `om-auto-implement-issue` opens a spec-first
+PR and then needs to implement it — which naively means running `om-auto-create-pr`,
+which opens *its own* PR. That second PR is a collision. Two decisions resolve it:
+
+- **`om-auto-implement-issue` implements by continuation, not by create.** After it
+  opens the one spec PR (with a tracking plan), implementation is handed to
+  `om-auto-continue-pr` (or `om-auto-continue-pr-loop` for a large, many-step spec —
+  the skill chooses per the plan size, which also dictates the plan format it
+  writes). The continue skills resume from the plan **on the existing PR** and reuse
+  the identical implement/validate/review/label/summary machinery without opening
+  anything new. So there is exactly one PR.
+- **PR opening + labeling is one reusable procedure**, documented once in
+  `om-auto-create-pr/references/pr-open-reuse.md` and pointed at by the create,
+  continue, and implement skills: **prefer the `om-open-pr` skill when it is
+  installed** (it already implements commit → push → open draft PR → normalize
+  labels, so reuse it instead of duplicating), and **fall back to the inline
+  `create-pr` + label path when it is not** — `om-open-pr` is an optional
+  enhancement that removes duplication without changing behavior, so a repo that
+  installs `om-auto-create-pr` alone still works. The invariant across all of them:
+  never open a second PR for work that already has one.
+
+`om-auto-manage-issues` also gained a read-only implementation-prep pass: it can run
+a root-cause/impact analysis (delegating to `om-root-cause` for bugs when installed)
+and post it as an "implementation notes" comment so an existing issue is ready to
+fix — autonomously, never interactively, and defaulting off for batches because it
+reads code per issue.
+
 ## PR-side driver: om-auto-fix-pr
 
 The issue side had a single-command end-to-end driver (`om-auto-fix-issue`); the PR

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -70,15 +70,18 @@ features: when none exists in the repo or an open PR, it authors one via the sam
 `--spec-only` spec PR and links it on the issue — its one exception to being
 tracker-only, and design-only (never implementation).
 
-`om-spec-writing`'s Open Questions gate is a hard human stop, which is correct
-interactively but would strand an autonomous run (e.g. `om-auto-fix-issue` routing
-a feature request). So `om-auto-implement-issue` takes an `--autonomous` mode
-(passed by `om-auto-fix-issue`, implied when unattended): instead of stopping, it
-resolves each open question with a conservative, reversible default, records the
-assumptions in the spec, and posts the questions + applied defaults as an issue/PR
-comment for a human to override before merge — keeping the PR draft/`needs-qa` when
-any default is high-stakes. Progress beats stalling, as long as every assumption is
-surfaced and reversible and nothing merges on assumptions alone.
+`om-spec-writing`'s Open Questions gate is a hard human stop, which is correct when
+a person is driving but would strand an `om-auto-*` run (e.g. `om-auto-fix-issue`
+routing a feature request, or `om-prepare-issue` authoring a required spec). Since
+the `om-auto-*` family is autonomous by definition, `om-auto-implement-issue` runs
+**autonomous by default**: instead of stopping at the gate it resolves each open
+question with a conservative, reversible default, records the assumptions in the
+spec, and posts the questions + applied defaults as an issue/PR comment for a human
+to override before merge — keeping the PR draft/`needs-qa` when any default is
+high-stakes. A `--interactive` flag opts back into the human stop for the cases
+where a person wants to make the design calls. Progress beats stalling, as long as
+every assumption is surfaced and reversible and nothing merges on assumptions
+alone.
 
 ## Issue skills split: create vs manage
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -70,6 +70,16 @@ features: when none exists in the repo or an open PR, it authors one via the sam
 `--spec-only` spec PR and links it on the issue — its one exception to being
 tracker-only, and design-only (never implementation).
 
+`om-spec-writing`'s Open Questions gate is a hard human stop, which is correct
+interactively but would strand an autonomous run (e.g. `om-auto-fix-issue` routing
+a feature request). So `om-auto-implement-issue` takes an `--autonomous` mode
+(passed by `om-auto-fix-issue`, implied when unattended): instead of stopping, it
+resolves each open question with a conservative, reversible default, records the
+assumptions in the spec, and posts the questions + applied defaults as an issue/PR
+comment for a human to override before merge — keeping the PR draft/`needs-qa` when
+any default is high-stakes. Progress beats stalling, as long as every assumption is
+surfaced and reversible and nothing merges on assumptions alone.
+
 ## Issue skills split: create vs manage
 
 `om-prepare-issue` conflated two jobs — filing a *new* issue and improving

--- a/skills/om-auto-continue-pr-loop/SKILL.md
+++ b/skills/om-auto-continue-pr-loop/SKILL.md
@@ -367,6 +367,13 @@ secrets into it.
 
 ### 9. Update the PR, normalize labels, release the lock
 
+This step **updates the existing PR** — it never opens a new one (the duplicate-PR
+collision `om-auto-create-pr/references/pr-open-reuse.md` guards against). Its
+commit/push and label-normalization mechanics follow that shared reference:
+**prefer the `om-open-pr` skill when installed** (reuse its push + label
+normalization instead of duplicating it), falling back to the inline tracker
+operations below when it is not — so this skill works standalone.
+
 Update the PR body:
 
 - If every row in the Tasks table now has `Status: done`, flip the PR body's `Status: in-progress` to `Status: complete`.

--- a/skills/om-auto-continue-pr/SKILL.md
+++ b/skills/om-auto-continue-pr/SKILL.md
@@ -214,6 +214,13 @@ into it.
 
 ### 9. Update the PR, normalize labels, release the lock
 
+This step **updates the existing PR** — it never opens a new one (that would be the
+duplicate-PR collision `om-auto-create-pr/references/pr-open-reuse.md` guards
+against). The commit/push and label-normalization mechanics follow that shared
+reference: **prefer the `om-open-pr` skill when it is installed** (reuse its
+push + label-normalization rather than duplicating it), and fall back to the inline
+tracker operations below when it is not — so this skill works standalone.
+
 Update the PR body:
 
 - If all Progress steps are now `- [x]`, flip `Status: in-progress` to `Status: complete`.

--- a/skills/om-auto-create-pr/SKILL.md
+++ b/skills/om-auto-create-pr/SKILL.md
@@ -202,11 +202,16 @@ If self-review finds issues, fix them and loop back to step 6.
 
 ### 9. Open the PR
 
-Open the PR via the tracker operation **create-pr** against `$BASE_BRANCH` in the
-current repository, with a conventional-commit-prefixed title scoped to the
-primary area. Use the PR body template in `references/pr-body-template.md` — it
-**MUST** include the `Tracking plan:` line so `om-auto-continue-pr` can resume.
-Flip `Status:` to `complete` on the PR body once all Progress steps are checked.
+Open (or reuse) the PR following `references/pr-open-reuse.md`: **prefer the
+`om-open-pr` skill when it is installed** (it performs the commit → push → open
+draft PR → normalize labels mechanics and is the single shared implementation), and
+**fall back to the inline path** — the tracker operation **create-pr** against
+`$BASE_BRANCH` — when it is not, so this skill works standalone without `om-open-pr`.
+Either way, never open a second PR when one already exists for the branch. Use a
+conventional-commit-prefixed title scoped to the primary area and the PR body
+template in `references/pr-body-template.md` — it **MUST** include the
+`Tracking plan:` line so `om-auto-continue-pr` can resume. Flip `Status:` to
+`complete` on the PR body once all Progress steps are checked.
 
 ### 10. Normalize labels
 

--- a/skills/om-auto-create-pr/references/pr-open-reuse.md
+++ b/skills/om-auto-create-pr/references/pr-open-reuse.md
@@ -1,0 +1,51 @@
+# Opening / reusing the PR — prefer `om-open-pr`, fall back inline
+
+The single procedure for the "commit → push → open (or reuse) the PR → normalize
+labels" mechanics, shared by `om-auto-create-pr` (step 9), `om-auto-continue-pr`,
+`om-auto-continue-pr-loop`, and `om-auto-implement-issue`. The point is to have
+**one** implementation of PR opening + labeling, reused rather than copied, and to
+never open a second PR for work that already has one.
+
+## Never open a duplicate PR
+
+Before opening anything, check whether a PR already exists for this branch (or, in
+an issue-driven run, one that references the issue) via **search-prs** / **get-pr**.
+If one exists, **reuse it** — push new commits to its head branch and update its
+body/labels — never open a second PR. This is the collision that alignment across
+the create/continue/implement skills exists to prevent: only the skill that first
+opens the PR owns opening it; everyone else updates that same PR.
+
+## Prefer the `om-open-pr` skill when installed
+
+`om-open-pr` already implements exactly this: it commits the worktree, pushes the
+branch, opens a **draft** PR against `$BASE_BRANCH`, normalizes labels through the
+descriptor guards, and (in an issue-driven run) hands the issue back and releases
+the `in-progress` lock — emitting `PR_URL=` / `PR_NUMBER=` markers. When it is
+installed, **delegate to it** instead of re-deriving the steps, so there is no
+duplicated PR-opening logic across skills:
+
+- Issue-driven run (an `{issueId}` is in scope — e.g. `om-auto-implement-issue`):
+  invoke `om-open-pr {issueId}` verbatim and capture its `PR_URL` / `PR_NUMBER`.
+- Brief-driven run (no issue — e.g. `om-auto-create-pr` from a task brief): reuse
+  its commit/push/open-draft/label mechanics; skip the issue-handback and
+  lock-release parts, which do not apply when there is no issue.
+
+## Graceful fallback when `om-open-pr` is NOT installed
+
+`om-open-pr` is an **optional** enhancement — a repo may install `om-auto-create-pr`
+(or the continue/implement skills) without it, and they must still work. When
+`om-open-pr` is absent, perform the mechanics inline:
+
+1. Commit the worktree changes with a conventional-commit subject; push the branch.
+2. Open the PR via the tracker operation **create-pr** against `$BASE_BRANCH` (as a
+   draft when the caller wants spec-first / resumable review), with the caller's PR
+   body template (e.g. `references/pr-body-template.md`) — which **must** carry the
+   `Tracking plan:` line so `om-auto-continue-pr` can resume.
+3. Normalize labels via `references/label-normalization.md`, each through the
+   `apply_label` guard (missing label → logged skip; `labels.enabled:false` → skip
+   all), and post the short per-label rationale comments.
+
+Detect availability simply: if invoking `om-open-pr` is not possible in this
+environment (skill not present), take the inline path. Behavior is identical either
+way — the same PR, the same labels — so a repo's choice to install `om-open-pr` only
+removes duplication, it never changes the outcome.

--- a/skills/om-auto-fix-issue/SKILL.md
+++ b/skills/om-auto-fix-issue/SKILL.md
@@ -63,11 +63,12 @@ If the issue is a **feature request**, do not run the bug chain: instead delegat
 the whole run to the `om-auto-implement-issue` skill with `{issueId}` (and
 `{repo}`, `--force` if it was set), which confirms the feature is not already
 implemented, writes (or reuses) a spec and lands it on a PR, then implements it.
-Because this chain is an autonomous driver, pass **`--autonomous`** on the
-delegation so the spec's Open Questions gate does not stall the run — the delegated
-skill resolves any open questions with conservative documented defaults and posts
-them as an issue/PR comment for a human to override before merge, rather than
-stopping. Follow that skill's workflow verbatim and stop this chain — it owns the
+That skill is autonomous by default, so the spec's Open Questions gate will not
+stall this chain — it resolves any open questions with conservative documented
+defaults and posts them as an issue/PR comment for a human to override before
+merge, rather than stopping (pass `--interactive` only if a human is driving and
+wants to answer the design questions). Follow that skill's workflow verbatim and
+stop this chain — it owns the
 claim, the PR, and the report from here. When an issue mixes a defect and a new
 capability, prefer stopping and asking the user to split it (bug → this chain, FR
 → `om-auto-implement-issue`) rather than guessing. Only when the issue is a bug
@@ -201,7 +202,7 @@ When the run stopped at step 2, cite the `om-verify-in-repo` evidence (existing 
 ## Rules
 
 - Always run the step 1 concurrency check before anything else; never silently override another actor's claim — `--force` must post an explicit override comment.
-- Classify before triaging: a feature request is routed to `om-auto-implement-issue` with `--autonomous` (which specs-then-builds it and resolves the spec's Open Questions with documented defaults + an override comment instead of stopping), never run through the bug-confirmation gate; only bugs continue on this chain. When unsure, default to the bug chain; when an issue mixes both, ask the user to split it.
+- Classify before triaging: a feature request is routed to `om-auto-implement-issue` (autonomous by default, so it specs-then-builds it and resolves the spec's Open Questions with documented defaults + an override comment instead of stopping), never run through the bug-confirmation gate; only bugs continue on this chain. When unsure, default to the bug chain; when an issue mixes both, ask the user to split it.
 - Claiming belongs to `om-fix`; this skill never claims an issue before the triage gate confirms there is work to do.
 - The `in-progress` lock is always released by the end of the run: by `om-open-pr` on the success path, or by step 8 on any failure after the claim.
 - Invoke each chain skill's workflow verbatim and pass outputs between steps verbatim, in the exact marked blocks the next step parses.

--- a/skills/om-auto-fix-issue/SKILL.md
+++ b/skills/om-auto-fix-issue/SKILL.md
@@ -63,8 +63,12 @@ If the issue is a **feature request**, do not run the bug chain: instead delegat
 the whole run to the `om-auto-implement-issue` skill with `{issueId}` (and
 `{repo}`, `--force` if it was set), which confirms the feature is not already
 implemented, writes (or reuses) a spec and lands it on a PR, then implements it.
-Follow that skill's workflow verbatim and stop this chain — it owns the claim,
-the PR, and the report from here. When an issue mixes a defect and a new
+Because this chain is an autonomous driver, pass **`--autonomous`** on the
+delegation so the spec's Open Questions gate does not stall the run — the delegated
+skill resolves any open questions with conservative documented defaults and posts
+them as an issue/PR comment for a human to override before merge, rather than
+stopping. Follow that skill's workflow verbatim and stop this chain — it owns the
+claim, the PR, and the report from here. When an issue mixes a defect and a new
 capability, prefer stopping and asking the user to split it (bug → this chain, FR
 → `om-auto-implement-issue`) rather than guessing. Only when the issue is a bug
 (or you cannot defend "feature request") do you continue to step 2.
@@ -197,7 +201,7 @@ When the run stopped at step 2, cite the `om-verify-in-repo` evidence (existing 
 ## Rules
 
 - Always run the step 1 concurrency check before anything else; never silently override another actor's claim — `--force` must post an explicit override comment.
-- Classify before triaging: a feature request is routed to `om-auto-implement-issue` (which specs-then-builds it), never run through the bug-confirmation gate; only bugs continue on this chain. When unsure, default to the bug chain; when an issue mixes both, ask the user to split it.
+- Classify before triaging: a feature request is routed to `om-auto-implement-issue` with `--autonomous` (which specs-then-builds it and resolves the spec's Open Questions with documented defaults + an override comment instead of stopping), never run through the bug-confirmation gate; only bugs continue on this chain. When unsure, default to the bug chain; when an issue mixes both, ask the user to split it.
 - Claiming belongs to `om-fix`; this skill never claims an issue before the triage gate confirms there is work to do.
 - The `in-progress` lock is always released by the end of the run: by `om-open-pr` on the success path, or by step 8 on any failure after the claim.
 - Invoke each chain skill's workflow verbatim and pass outputs between steps verbatim, in the exact marked blocks the next step parses.

--- a/skills/om-auto-implement-issue/SKILL.md
+++ b/skills/om-auto-implement-issue/SKILL.md
@@ -125,44 +125,49 @@ posting the questions + applied defaults as an issue/PR comment for later overri
 `--interactive` was passed is the gate a hard human checkpoint — then present the
 questions and stop until the user answers, and never answer your own gate
 questions.
-Commit the spec as the first code commit, write the Progress-tracked execution
-plan under `$RUNS_DIR` referencing the spec as `Source doc:`, push, and open a
-**draft PR** so the design is visible on the PR before any implementation lands.
-If `--spec-only` was passed, stop here with `Status: in-progress` and hand off to
-`om-auto-continue-pr {prNumber}`.
+Commit the spec as the first code commit. Then, before writing the plan, decide the
+implementation engine (`om-auto-continue-pr` vs `om-auto-continue-pr-loop`) per
+`references/implementation-engine-selection.md`, because the two consume different
+plan formats — write the plan under `$RUNS_DIR` in the matching format, referencing
+the spec as `Source doc:`. Push, and open (or reuse) a **draft PR** following
+`references/pr-open-reuse.md` — prefer `om-open-pr` when installed, inline
+`create-pr` otherwise, never a duplicate — so the design is visible on the PR before
+any implementation lands. If `--spec-only` was passed, stop here with
+`Status: in-progress` and hand off to `om-auto-continue-pr {prNumber}`.
 
-### 5. Implement the spec phase-by-phase
+### 5. Implement by continuation on the existing PR — never open a second PR
 
-Run the `om-auto-create-pr` implementation loop (its steps 6–8) against the spec's
-Implementation Plan: implement one Phase at a time, add mandatory tests for every
-code change, run the targeted subset of `validation.commands`, remove scope creep,
-commit per Step/Phase, tick the plan's Progress boxes with commit SHAs, and push
-after every Phase. Then run the full validation gate (all `validation.commands`)
-and the `om-code-review` + breaking-change self-review before marking the PR
-ready. Docs-only FRs are exempt from the unit-test rule but still run the
-configured lint/check.
+The alignment that keeps this skill from colliding with `om-auto-create-pr`:
+`om-auto-create-pr` **opens a new PR**, but step 4 already opened one (the
+spec-first PR) and wrote its tracking plan. So implementation runs as a
+**continuation of that same PR**, not a fresh create — hand it to the continue
+skills, which resume from the plan on the existing PR/branch and reuse the exact
+implement → validate → review → label → summary machinery without opening a
+duplicate. Choose the engine per `references/implementation-engine-selection.md`:
 
-### 6. Mark ready, link the issue, normalize labels
+- **`om-auto-continue-pr {prNumber}`** for an ordinary spec — it resumes from the
+  first unchecked Progress step, implements phase-by-phase with the validation gate
+  and the `om-auto-review-pr` autofix loop, and drives the PR to `complete`.
+- **`om-auto-continue-pr-loop {prNumber}`** for a large, many-step spec — the
+  checkpointed run-folder variant (requires step 4 to have written the plan in the
+  run-folder format that skill expects).
 
-Follow `references/pr-linkage.md`: flip the PR out of draft, ensure the body
-carries `Source doc: {spec path}`, `Tracking plan: {plan path}`, and — because this
-is the implementing PR — a `Closes #{issueId}` line so the merge auto-closes the FR
-(a `--spec-only` design PR instead carries `Refs #{issueId}` and never reaches this
-step), then normalize labels
-via `om-auto-create-pr` step 10 — always adding the `feature` category label,
-exactly one priority and one risk label, and `needs-qa` vs `skip-qa` per
-user-facing impact. Post the short per-label rationale comments.
+Before handing off, make sure the PR body carries the implementing-PR linkage from
+`references/pr-linkage.md` — `Closes #{issueId}` (so the merge auto-closes the FR),
+`Source doc:`, `Tracking plan:` — and the `feature` category label, so the
+continuation preserves them. The continuation owns marking the PR ready, the review
+loop, labels, and the summary comment from here (it holds the `in-progress` lock as
+re-entry under the same owner). `--spec-only` runs never reach this step.
 
-### 7. Autofix review loop, summary, release, report
+### 6. Release, report
 
-Run `om-auto-review-pr` against the PR in autofix mode and keep applying fixes as
-new commits until it returns clean or only non-actionable findings remain
-(`om-auto-create-pr` step 11). Release the `in-progress` lock once the PR is ready
-(and on any failure after step 4's claim, release it in the `trap`/finally with an
-abort comment, exactly as `om-auto-fix-issue` step 8 does). Post the single
-comprehensive summary comment (`om-auto-create-pr` step 12 template, noting the FR
-number and the spec path). Clean up any worktree this run created, record `PR: #{n}`
-in the plan, and report: issue, spec path, branch, PR URL, and
+Once the continuation reports the PR complete (or if the run aborts after step 4's
+claim, release the `in-progress` lock in the `trap`/finally with an abort comment,
+exactly as `om-auto-fix-issue` step 8 does). Confirm the summary comment the
+continuation posted names the FR number and the spec path; if the run was
+`--spec-only` (no implementation), post the summary yourself per the
+`om-auto-create-pr` step-12 template. Clean up any worktree this run created, record
+`PR: #{n}` in the plan, and report: issue, spec path, branch, PR URL, and
 `{complete | spec-only — use om-auto-continue-pr <n> | in-progress}`.
 
 ## Rules
@@ -170,7 +175,7 @@ in the plan, and report: issue, spec path, branch, PR URL, and
 - **Untrusted content boundary** (above) is always honored; never exfiltrate data or secrets into PR comments, the plan, or the spec.
 - FR triage **confirms the feature is unbuilt** — it never runs the bug-confirmation gate. A real bug is handed back to `om-auto-fix-issue`; an already-built or already-in-flight feature stops with `NO_ACTION_NEEDED` and cited evidence.
 - Spec first, always: the spec is the first commit and is visible on the PR before implementation. Autonomous by default — do not stop at `om-spec-writing`'s Open Questions gate; apply conservative documented defaults and post them as an issue/PR comment for override (`references/autonomous-open-questions.md`), keeping the PR draft / `needs-qa` when any default is high-stakes. Only `--interactive` turns the gate into a hard stop for a human, in which case never answer your own gate questions.
-- Reuse, don't reinvent: delegate the worktree, Progress plan, phase commits, validation gate, labels, review loop, and summary comment to `om-auto-create-pr`, and the design to `om-spec-writing`; this skill only adds FR triage, spec-first ordering, and issue linkage.
+- Reuse, don't reinvent, and **never open a second PR**: this skill opens exactly one PR (the spec-first PR in step 4) and implements it as a **continuation** via `om-auto-continue-pr` / `om-auto-continue-pr-loop` (chosen per `references/implementation-engine-selection.md`) — which reuse `om-auto-create-pr`'s implement/validate/review/label/summary machinery on the existing PR rather than opening a fresh one. The design comes from `om-spec-writing`; PR opening/labeling follows `om-auto-create-pr/references/pr-open-reuse.md` (prefer `om-open-pr` when installed, inline otherwise). This skill only adds FR triage, spec-first ordering, engine selection, and issue linkage.
 - Every code change ships with tests; docs-only FRs still run the configured lint/check. Run the full `validation.commands` gate before marking the PR ready unless a real blocker prevents it — then document it.
 - The base branch always comes from config (`baseBranch`); never hard-code it. All tracker interaction goes through named operations via the descriptor.
 - Claim through the three-signal protocol; release the `in-progress` lock when the run reaches a terminal state (on success once the PR is ready, or in the failure `trap` on any abort) — a crashed run must never leak a lock or a worktree. The one exception is a `--spec-only` hand-off, which deliberately **retains** the lock as the resume marker for `om-auto-continue-pr` (the resuming run releases it); a hand-off is not a leak.

--- a/skills/om-auto-implement-issue/SKILL.md
+++ b/skills/om-auto-implement-issue/SKILL.md
@@ -24,6 +24,7 @@ with no tracker issue, use `om-auto-create-pr` directly; for a defect, use
 - `{issueId}` (required) — the FR issue number in the tracker (a GitHub issue number by default), e.g. `1234`
 - `{repo}` (optional) — `owner/name`; if omitted, infer from the current git remote
 - `--spec-only` (optional) — stop after the spec lands on the PR; leave implementation to a later `om-auto-continue-pr {prNumber}` run (spec-reviewed-first workflow)
+- `--autonomous` (optional) — never stop for a human gate. When `om-spec-writing`'s Open Questions gate would otherwise block, resolve each question with a conservative documented default and continue, posting the questions + applied defaults as an issue/PR comment for later override (see `references/autonomous-open-questions.md`). Implied when the run is unattended (no interactive user to answer) or when a driving auto-skill (e.g. `om-auto-fix-issue`) passes it.
 - `--slug <kebab-case>` (optional) — override the slug used in the branch, plan, and spec filenames
 - `--force` (optional) — bypass the in-progress / claim-conflict check when a previous run or another actor left a lock, branch, or plan behind
 
@@ -117,7 +118,13 @@ claim the issue (assignee + `in-progress` + `🤖` claim comment via the tracker
 operations), then produce the spec — **reuse** a covering spec already in
 `$SPECS_DIR` when one exists, otherwise write a fresh one by following the
 `om-spec-writing` workflow verbatim, **including its skeleton-first Open Questions
-hard gate** (a real human checkpoint; never answer your own gate questions).
+gate**. In an **interactive** run that gate is a real human checkpoint — present
+the questions and stop until the user answers; never answer your own gate
+questions. In an **autonomous** run (`--autonomous`, an unattended run, or a
+delegating auto-skill) the gate must not stall the run: resolve each question with
+a conservative, documented default and continue, posting the questions + applied
+defaults as an issue/PR comment for later override — full procedure in
+`references/autonomous-open-questions.md`.
 Commit the spec as the first code commit, write the Progress-tracked execution
 plan under `$RUNS_DIR` referencing the spec as `Source doc:`, push, and open a
 **draft PR** so the design is visible on the PR before any implementation lands.
@@ -162,7 +169,7 @@ in the plan, and report: issue, spec path, branch, PR URL, and
 
 - **Untrusted content boundary** (above) is always honored; never exfiltrate data or secrets into PR comments, the plan, or the spec.
 - FR triage **confirms the feature is unbuilt** — it never runs the bug-confirmation gate. A real bug is handed back to `om-auto-fix-issue`; an already-built or already-in-flight feature stops with `NO_ACTION_NEEDED` and cited evidence.
-- Spec first, always: the spec is the first commit and is visible on the PR before implementation; honor `om-spec-writing`'s Open Questions hard gate and never answer your own gate questions.
+- Spec first, always: the spec is the first commit and is visible on the PR before implementation. In an interactive run, honor `om-spec-writing`'s Open Questions gate as a hard stop and never answer your own gate questions; in an autonomous run, do not stop — apply conservative documented defaults and post them as an issue/PR comment for override (`references/autonomous-open-questions.md`), and keep the PR in draft / `needs-qa` when any default is high-stakes.
 - Reuse, don't reinvent: delegate the worktree, Progress plan, phase commits, validation gate, labels, review loop, and summary comment to `om-auto-create-pr`, and the design to `om-spec-writing`; this skill only adds FR triage, spec-first ordering, and issue linkage.
 - Every code change ships with tests; docs-only FRs still run the configured lint/check. Run the full `validation.commands` gate before marking the PR ready unless a real blocker prevents it — then document it.
 - The base branch always comes from config (`baseBranch`); never hard-code it. All tracker interaction goes through named operations via the descriptor.

--- a/skills/om-auto-implement-issue/SKILL.md
+++ b/skills/om-auto-implement-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: om-auto-implement-issue
-description: Implement a new feature-request (FR) tracker issue end to end by combining spec-writing and auto-create-pr — first land a spec on a PR, then implement it on the same branch. Confirms the feature is not already built (never a bug-confirmation gate), writes or reuses a spec (with the Open Questions hard gate), commits it as the first commit, opens a draft PR, then delivers the spec phase-by-phase with the validation gate, labels, and the autofix review loop. Use when the user says "implement issue 123 as a feature", "build the FR in #123", "spec-then-build this feature request".
+description: Implement a new feature-request (FR) tracker issue end to end by combining spec-writing and auto-create-pr — first land a spec on a PR, then implement it on the same branch. Confirms the feature is not already built (never a bug-confirmation gate), writes or reuses a spec, commits it as the first commit, opens a draft PR, then delivers the spec phase-by-phase with the validation gate, labels, and the autofix review loop. Autonomous by default: at spec-writing's Open Questions gate it applies conservative documented defaults and posts them for override instead of stopping (pass --interactive to stop for a human). Use when the user says "implement issue 123 as a feature", "build the FR in #123", "spec-then-build this feature request".
 ---
 
 # Auto Implement Issue (FR → spec → PR → implementation)
@@ -24,7 +24,7 @@ with no tracker issue, use `om-auto-create-pr` directly; for a defect, use
 - `{issueId}` (required) — the FR issue number in the tracker (a GitHub issue number by default), e.g. `1234`
 - `{repo}` (optional) — `owner/name`; if omitted, infer from the current git remote
 - `--spec-only` (optional) — stop after the spec lands on the PR; leave implementation to a later `om-auto-continue-pr {prNumber}` run (spec-reviewed-first workflow)
-- `--autonomous` (optional) — never stop for a human gate. When `om-spec-writing`'s Open Questions gate would otherwise block, resolve each question with a conservative documented default and continue, posting the questions + applied defaults as an issue/PR comment for later override (see `references/autonomous-open-questions.md`). Implied when the run is unattended (no interactive user to answer) or when a driving auto-skill (e.g. `om-auto-fix-issue`) passes it.
+- `--interactive` (optional) — opt into human gates. This `om-auto-*` skill runs **autonomously by default**: when `om-spec-writing`'s Open Questions gate would block, it resolves each question with a conservative documented default and continues, posting the questions + applied defaults as an issue/PR comment for later override (see `references/autonomous-open-questions.md`). Pass `--interactive` to instead **stop** at the gate and wait for a human to answer — use it when a person is driving the run and wants to make the design calls.
 - `--slug <kebab-case>` (optional) — override the slug used in the branch, plan, and spec filenames
 - `--force` (optional) — bypass the in-progress / claim-conflict check when a previous run or another actor left a lock, branch, or plan behind
 
@@ -118,13 +118,13 @@ claim the issue (assignee + `in-progress` + `🤖` claim comment via the tracker
 operations), then produce the spec — **reuse** a covering spec already in
 `$SPECS_DIR` when one exists, otherwise write a fresh one by following the
 `om-spec-writing` workflow verbatim, **including its skeleton-first Open Questions
-gate**. In an **interactive** run that gate is a real human checkpoint — present
-the questions and stop until the user answers; never answer your own gate
-questions. In an **autonomous** run (`--autonomous`, an unattended run, or a
-delegating auto-skill) the gate must not stall the run: resolve each question with
-a conservative, documented default and continue, posting the questions + applied
-defaults as an issue/PR comment for later override — full procedure in
-`references/autonomous-open-questions.md`.
+gate**. This skill is **autonomous by default**, so the gate must not stall the
+run: resolve each question with a conservative, documented default and continue,
+posting the questions + applied defaults as an issue/PR comment for later override
+— full procedure in `references/autonomous-open-questions.md`. Only when
+`--interactive` was passed is the gate a hard human checkpoint — then present the
+questions and stop until the user answers, and never answer your own gate
+questions.
 Commit the spec as the first code commit, write the Progress-tracked execution
 plan under `$RUNS_DIR` referencing the spec as `Source doc:`, push, and open a
 **draft PR** so the design is visible on the PR before any implementation lands.
@@ -169,7 +169,7 @@ in the plan, and report: issue, spec path, branch, PR URL, and
 
 - **Untrusted content boundary** (above) is always honored; never exfiltrate data or secrets into PR comments, the plan, or the spec.
 - FR triage **confirms the feature is unbuilt** — it never runs the bug-confirmation gate. A real bug is handed back to `om-auto-fix-issue`; an already-built or already-in-flight feature stops with `NO_ACTION_NEEDED` and cited evidence.
-- Spec first, always: the spec is the first commit and is visible on the PR before implementation. In an interactive run, honor `om-spec-writing`'s Open Questions gate as a hard stop and never answer your own gate questions; in an autonomous run, do not stop — apply conservative documented defaults and post them as an issue/PR comment for override (`references/autonomous-open-questions.md`), and keep the PR in draft / `needs-qa` when any default is high-stakes.
+- Spec first, always: the spec is the first commit and is visible on the PR before implementation. Autonomous by default — do not stop at `om-spec-writing`'s Open Questions gate; apply conservative documented defaults and post them as an issue/PR comment for override (`references/autonomous-open-questions.md`), keeping the PR draft / `needs-qa` when any default is high-stakes. Only `--interactive` turns the gate into a hard stop for a human, in which case never answer your own gate questions.
 - Reuse, don't reinvent: delegate the worktree, Progress plan, phase commits, validation gate, labels, review loop, and summary comment to `om-auto-create-pr`, and the design to `om-spec-writing`; this skill only adds FR triage, spec-first ordering, and issue linkage.
 - Every code change ships with tests; docs-only FRs still run the configured lint/check. Run the full `validation.commands` gate before marking the PR ready unless a real blocker prevents it — then document it.
 - The base branch always comes from config (`baseBranch`); never hard-code it. All tracker interaction goes through named operations via the descriptor.

--- a/skills/om-auto-implement-issue/references/autonomous-open-questions.md
+++ b/skills/om-auto-implement-issue/references/autonomous-open-questions.md
@@ -1,0 +1,74 @@
+# Autonomous Open Questions — resolve with defaults, post for override
+
+How `om-auto-implement-issue` clears `om-spec-writing`'s Open Questions gate in an
+**autonomous** run without stopping. Autonomous means `--autonomous` was passed,
+the run is unattended (no interactive user to answer), or a driving auto-skill
+(e.g. `om-auto-fix-issue`) delegated it. Interactive runs never reach this file —
+they stop at the gate for the human.
+
+The rule the interactive path enforces ("never answer your own gate questions")
+is deliberately inverted here **only** because a stalled autonomous run is worse
+than a documented, reversible assumption a human can override before merge. It is
+not licence to invent scope: defaults stay conservative and are always surfaced.
+
+## 1. Choose a default per question
+
+For each numbered Open Question, pick the answer that is **most reversible and
+lowest-blast-radius**, biased toward the smallest scope that still ships something
+working:
+
+- Prefer the option that adds the least new surface (no new public contract, no
+  new dependency, no schema change) — those are the expensive-to-undo choices.
+- Prefer reusing the project's existing primitives/conventions over inventing new
+  ones (per the repo's agent instructions).
+- When the question is "should this also do X?", default to **no / defer X** and
+  let a follow-up add it.
+- When a question genuinely cannot be defaulted without risking a large rewrite or
+  touching a protected/`BACKWARD_COMPATIBILITY.md` surface, still pick the most
+  reversible option but mark it **NEEDS HUMAN CONFIRMATION** and treat the run as
+  high-stakes (see step 4).
+
+Write one short rationale sentence per default. Never default in a way that
+weakens security, data scoping, or a documented compatibility contract — those are
+never "assume and proceed"; mark them NEEDS HUMAN CONFIRMATION instead.
+
+## 2. Resolve the spec's Open Questions block
+
+Apply each default into the spec so the document is internally complete: replace
+the `Open Questions` block with a `## Resolved assumptions (autonomous defaults)`
+section listing, per question, the chosen answer, its rationale, and a
+`⚠ NEEDS HUMAN CONFIRMATION` marker where it applies. The spec must read as a
+coherent design under those assumptions — do not leave dangling references to an
+unanswered question.
+
+## 3. Post the questions + defaults as a comment
+
+So a human can override before anything merges, post one comment via
+**comment-issue** on the FR issue (it always exists at this point) and, once the
+PR is open in step 4, the same content via **comment-pr** on the PR:
+
+```markdown
+🤖 `om-auto-implement-issue` — Open Questions answered with autonomous defaults
+
+This spec had open questions and the run is autonomous, so I applied conservative
+defaults to keep moving. **Please review and override before merge if any is wrong.**
+
+| # | Question | Applied default | Why | Confirm? |
+|---|----------|-----------------|-----|----------|
+| Q1 | {question} | {default} | {one-line rationale} | {ok / ⚠ needs human} |
+| Q2 | … | … | … | … |
+
+To change any answer: reply here (or edit the spec) and re-run
+`om-auto-continue-pr {prNumber}` / `om-auto-implement-issue {issueId}`.
+```
+
+Use a stable marker (`🤖 om-auto-implement-issue — Open Questions`) so a re-run
+detects an existing defaults comment and updates it instead of posting a duplicate.
+
+## 4. High-stakes guard
+
+If **any** question was marked `⚠ NEEDS HUMAN CONFIRMATION`, do not present the run
+as fully merge-ready on defaults alone: keep the PR a **draft** (or apply
+`needs-qa`), state in the PR body and the step-12 summary that merge is gated on a
+human confirming those specific assumptions, and never add `qa-approved`. Ordinary
+low-risk defaults do not require this — the review comment is enough for them.

--- a/skills/om-auto-implement-issue/references/autonomous-open-questions.md
+++ b/skills/om-auto-implement-issue/references/autonomous-open-questions.md
@@ -1,10 +1,9 @@
 # Autonomous Open Questions — resolve with defaults, post for override
 
-How `om-auto-implement-issue` clears `om-spec-writing`'s Open Questions gate in an
-**autonomous** run without stopping. Autonomous means `--autonomous` was passed,
-the run is unattended (no interactive user to answer), or a driving auto-skill
-(e.g. `om-auto-fix-issue`) delegated it. Interactive runs never reach this file —
-they stop at the gate for the human.
+How `om-auto-implement-issue` clears `om-spec-writing`'s Open Questions gate
+without stopping. As an `om-auto-*` skill it is **autonomous by default**, so this
+is the normal path; the only exception is an explicit `--interactive` run, which
+stops at the gate for the human and never reaches this file.
 
 The rule the interactive path enforces ("never answer your own gate questions")
 is deliberately inverted here **only** because a stalled autonomous run is worse

--- a/skills/om-auto-implement-issue/references/implementation-engine-selection.md
+++ b/skills/om-auto-implement-issue/references/implementation-engine-selection.md
@@ -1,0 +1,48 @@
+# Choosing the implementation engine — continue vs continue-loop
+
+How `om-auto-implement-issue` step 5 picks the engine that implements the spec, and
+why implementation is a **continuation** rather than a fresh `om-auto-create-pr`
+run.
+
+## Why continuation, not a new create-pr run
+
+`om-auto-create-pr` opens a **new** PR as part of its flow. This skill has already
+opened a PR in step 4 (the spec-first PR) and written its tracking plan. Running a
+fresh `om-auto-create-pr` on top would open a **second** PR for the same work — the
+collision this design avoids. The continue skills (`om-auto-continue-pr`,
+`om-auto-continue-pr-loop`) resume from a tracking plan **on the existing PR** and
+reuse the identical implement → validate → self-review → `om-auto-review-pr` loop →
+label → summary machinery, without opening anything new. So implementation is
+always a continuation of the spec PR.
+
+(The commit/push/label mechanics inside those skills follow
+`om-auto-create-pr/references/pr-open-reuse.md`: prefer `om-open-pr` when installed,
+inline otherwise, and never open a duplicate PR.)
+
+## The choice
+
+Read the spec's **Implementation Plan** (Phases → Steps) and pick:
+
+- **`om-auto-continue-pr`** — the default. Use it for an ordinary spec: a handful of
+  phases, a bounded number of steps, no need for mid-run checkpoints. Step 4 wrote a
+  standard Progress-checklist plan (the format `om-auto-continue-pr` parses), so it
+  resumes from the first unchecked step and drives to `complete`.
+- **`om-auto-continue-pr-loop`** — for a **large, many-step** spec where resumability
+  and strict step tracking matter: many phases/steps (roughly >8–10 steps), UI work
+  needing screenshots, or a plan that will not finish in one pass. It expects the
+  **run-folder** format (`PLAN.md` Tasks table + `HANDOFF.md`/`NOTIFY.md`) that
+  `om-auto-create-pr-loop` writes and checkpoints every ~5 steps.
+
+## Consequence for step 4's plan format
+
+Decide the engine **before** writing the plan in step 4, because the two engines
+consume different plan formats:
+
+- Choosing `om-auto-continue-pr` → write the standard Progress-tracked execution
+  plan (per `om-auto-create-pr` step 3 / `references/spec-first-flow.md`).
+- Choosing `om-auto-continue-pr-loop` → write the run-folder instead, in the format
+  `om-auto-create-pr-loop` defines (its `PLAN.md`/`HANDOFF.md`/`NOTIFY.md`), derived
+  from the spec's phases and steps.
+
+When in doubt, prefer the plain `om-auto-continue-pr` engine — the loop variant is
+justified by scale, not used by default.

--- a/skills/om-auto-implement-issue/references/spec-first-flow.md
+++ b/skills/om-auto-implement-issue/references/spec-first-flow.md
@@ -44,27 +44,35 @@ Two paths, decided by triage:
 The spec's **Implementation Plan** (Phases → testable Steps) is what step 5
 executes, so make sure it exists and each step leaves the app working.
 
-## 3. Commit the spec and write the execution plan
+## 3. Commit the spec, choose the engine, and write the execution plan
 
 - Commit the spec as the first code commit:
   `docs(specs): add spec for {slug} (FR #{issueId})`.
-- Write the Progress-tracked execution plan under `$RUNS_DIR/{DATE}-{slug}.md`
-  using the `om-auto-create-pr` step 3 format, with two FR-specific lines:
-  `Source doc: {spec path}` and a note that the Progress phases mirror the spec's
-  Implementation Plan. Derive the Progress checklist directly from the spec's
-  Phases/Steps so `om-auto-continue-pr` can resume.
+- **Choose the implementation engine now** (`om-auto-continue-pr` vs
+  `om-auto-continue-pr-loop`) per `references/implementation-engine-selection.md`,
+  because the plan format depends on it.
+- Write the plan under `$RUNS_DIR`, referencing the spec as `Source doc:` and
+  deriving its steps directly from the spec's Phases/Steps:
+  - For `om-auto-continue-pr` (default): the Progress-tracked execution plan in the
+    `om-auto-create-pr` step-3 format (`{DATE}-{slug}.md` with the `## Progress`
+    checklist), so the continuation resumes from the first unchecked step.
+  - For `om-auto-continue-pr-loop` (large spec): the run-folder format
+    `om-auto-create-pr-loop` defines (`PLAN.md` Tasks table + `HANDOFF.md`/`NOTIFY.md`).
 - Commit the plan: `docs(runs): add execution plan for {slug}`.
 
-## 4. Push and open the draft PR
+## 4. Push and open (or reuse) the draft PR
 
-Push the branch, then open a **draft** PR via **create-pr** against
-`$BASE_BRANCH` with a conventional-commit title (`feat({area}): {feature}`). Use
-the PR body from `references/pr-linkage.md`, with the correct linkage line: a full
-run's PR will implement the feature, so it carries `Closes #{issueId}` from the
-start; a `--spec-only` design PR carries `Refs #{issueId}` (no closing keyword —
-see step 5). It also carries `Source doc:`, `Tracking plan:`, and
-`Status: in-progress`. Opening the PR now is what puts "the spec on a PR first":
-reviewers see the design commit before any implementation commit exists.
+Push the branch, then open a **draft** PR following
+`om-auto-create-pr/references/pr-open-reuse.md` — prefer the `om-open-pr` skill when
+installed, fall back to the **create-pr** tracker operation inline when it is not,
+and never open a duplicate PR if one already exists for the branch. Title:
+conventional-commit (`feat({area}): {feature}`). Use the PR body from
+`references/pr-linkage.md`, with the correct linkage line: a full run's PR will
+implement the feature, so it carries `Closes #{issueId}` from the start; a
+`--spec-only` design PR carries `Refs #{issueId}` (no closing keyword — see step 5).
+It also carries `Source doc:`, `Tracking plan:`, and `Status: in-progress`. Opening
+the PR now is what puts "the spec on a PR first": reviewers see the design commit
+before any implementation commit exists.
 
 ## 5. `--spec-only` branch
 

--- a/skills/om-auto-implement-issue/references/spec-first-flow.md
+++ b/skills/om-auto-implement-issue/references/spec-first-flow.md
@@ -28,17 +28,15 @@ Two paths, decided by triage:
   note precisely what you added.
 - **No spec**: write one by following the `om-spec-writing` workflow **verbatim**,
   including its skeleton-first drafting and its **Open Questions gate**. Handle the
-  gate by mode:
-  - **Interactive** (a user is present and `--autonomous` was not passed): the gate
-    is a genuine human checkpoint — present the skeleton with numbered Open
-    Questions and STOP until the user answers; never answer your own gate questions
-    to keep moving.
-  - **Autonomous** (`--autonomous`, an unattended run, or a delegating auto-skill
-    such as `om-auto-fix-issue`): do **not** stop. Resolve each Open Question with a
-    conservative, reversible default and continue, following
+  gate by mode (this skill is **autonomous by default**):
+  - **Autonomous** (the default — no `--interactive`): do **not** stop. Resolve each
+    Open Question with a conservative, reversible default and continue, following
     `references/autonomous-open-questions.md` — which also posts the questions +
     applied defaults as an issue/PR comment inviting a human to override before
     merge.
+  - **Interactive** (only when `--interactive` was passed): the gate is a genuine
+    human checkpoint — present the skeleton with numbered Open Questions and STOP
+    until the user answers; never answer your own gate questions to keep moving.
 
   Save the spec at `$SPECS_DIR/{YYYY-MM-DD}-{slug}.md` — the naming shape
   `om-followup-issue-from-pr` recognizes.

--- a/skills/om-auto-implement-issue/references/spec-first-flow.md
+++ b/skills/om-auto-implement-issue/references/spec-first-flow.md
@@ -27,14 +27,21 @@ Two paths, decided by triage:
   Do not rewrite it. If it only partially covers the FR, extend it minimally and
   note precisely what you added.
 - **No spec**: write one by following the `om-spec-writing` workflow **verbatim**,
-  including its skeleton-first drafting and its **Open Questions hard gate**. That
-  gate is a genuine human checkpoint — present the skeleton with numbered Open
-  Questions and STOP until the user answers; never answer your own gate questions
-  to keep moving. When running unattended with no user to answer, stop the run and
-  report that the spec needs the Open Questions resolved before implementation can
-  proceed (do not invent answers). Save the spec at
-  `$SPECS_DIR/{YYYY-MM-DD}-{slug}.md` — the naming shape `om-followup-issue-from-pr`
-  recognizes.
+  including its skeleton-first drafting and its **Open Questions gate**. Handle the
+  gate by mode:
+  - **Interactive** (a user is present and `--autonomous` was not passed): the gate
+    is a genuine human checkpoint — present the skeleton with numbered Open
+    Questions and STOP until the user answers; never answer your own gate questions
+    to keep moving.
+  - **Autonomous** (`--autonomous`, an unattended run, or a delegating auto-skill
+    such as `om-auto-fix-issue`): do **not** stop. Resolve each Open Question with a
+    conservative, reversible default and continue, following
+    `references/autonomous-open-questions.md` — which also posts the questions +
+    applied defaults as an issue/PR comment inviting a human to override before
+    merge.
+
+  Save the spec at `$SPECS_DIR/{YYYY-MM-DD}-{slug}.md` — the naming shape
+  `om-followup-issue-from-pr` recognizes.
 
 The spec's **Implementation Plan** (Phases → testable Steps) is what step 5
 executes, so make sure it exists and each step leaves the app working.

--- a/skills/om-auto-manage-issues/SKILL.md
+++ b/skills/om-auto-manage-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: om-auto-manage-issues
-description: Bring existing tracker issues up to standard without implementing anything — infer and apply the SDLC labels they are missing (category + priority + risk), and for a laconic issue (a one-line body, or just a title and a screenshot) analyze the attached screenshot together with the terse text, clarify the wording in the issue body, and post the agent's understanding as a comment for a human to confirm. Works on a single issue by id, or on a batch when none is given — defaulting to the most recent ~25 open issues, worst-described first, narrowable with --state/--label/--author/--limit. Idempotent and claim-aware. Use for "triage the backlog", "label these issues", "clean up issue 123", "enrich the last 25 issues".
+description: Bring existing tracker issues up to standard without implementing anything — infer and apply the SDLC labels they are missing (category + priority + risk); for a laconic issue (a one-line body, or just a title and a screenshot) analyze the attached screenshot together with the terse text, clarify the wording in the issue body, and post the agent's understanding as a comment for a human to confirm; and prepare the issue for implementation with a read-only root-cause / impact analysis posted as a comment (non-interactively) so the next agent or human can fix it. Works on a single issue by id, or on a batch when none is given — defaulting to the most recent ~25 open issues, worst-described first, narrowable with --state/--label/--author/--limit. Idempotent and claim-aware. Use for "triage the backlog", "label these issues", "clean up issue 123", "enrich the last 25 issues", "prepare issue 123 for implementation".
 ---
 
 # Auto Manage Issues (enrich existing issues)
@@ -28,7 +28,8 @@ different actor is actively working). For deep design work hand off to
 - `--state <open|closed|all>` (optional) — batch state filter. Default: `open`.
 - `--label <name>` (optional, repeatable) — restrict the batch to issues carrying (or, with `-<name>`, missing) a label.
 - `--author <login>` (optional) — restrict the batch to one author.
-- `--relabel-only` (optional) — apply missing SDLC labels but skip the screenshot/wording enrichment.
+- `--relabel-only` (optional) — apply missing SDLC labels but skip the screenshot/wording enrichment and the implementation-prep analysis.
+- `--prep-impl` / `--no-prep` (optional) — the read-only **implementation-prep analysis** (root-cause / impact notes posted as a comment to help the next agent or human fix it). It reads code, so it defaults to **on for a single `{issueId}`** and **off for a batch** (opt in per batch with `--prep-impl`, since it runs per issue); `--no-prep` disables it entirely. Always non-interactive.
 - `--dry-run` (optional) — report what would change per issue and mutate nothing.
 
 ## Step 0 — Load config and context
@@ -108,21 +109,30 @@ follow `references/enrich-existing-issue.md`, which:
    and post the agent's **understanding** as a single comment — only if an
    equivalent understanding comment from this skill is not already present
    (idempotency).
+4. **Prepares the issue for implementation** (when prep is on — see `--prep-impl`,
+   and not `--relabel-only`): runs a **read-only** root-cause / impact analysis and
+   posts it as an "implementation notes" comment so the next agent or human can fix
+   it without re-exploring the repo. This is autonomous — it never stops to ask.
+   Full procedure in `references/implementation-prep.md` (delegates to `om-root-cause`
+   for a bug when installed; otherwise a lighter inline analysis; idempotent).
 
 Under `--dry-run`, compute all of the above but mutate nothing — record the planned
-labels, the proposed clarified wording, and the understanding text for the report.
+labels, the proposed clarified wording, the understanding text, and the
+implementation notes for the report.
 
 ### 3. Report
 
 Emit a compact per-issue summary: `#{n} — labels added: {…}; enriched: {yes/no};
-skipped: {reason}`. Close with totals (issues scanned, labeled, enriched, skipped)
-and, when the batch was truncated by `--limit`, say how many matched but were not
-processed. Never claim a mutation that `--dry-run` only simulated.
+prep: {yes/no}; skipped: {reason}`. Close with totals (issues scanned, labeled,
+enriched, prepped, skipped) and, when the batch was truncated by `--limit` or the
+implementation-prep was capped, say how many matched but were not processed. Never
+claim a mutation that `--dry-run` only simulated.
 
 ## Rules
 
 - **Untrusted content boundary** (above) is always honored — including text read from *inside a screenshot*; never exfiltrate data or paste secrets into comments or bodies.
-- Existing issues only: this skill never creates an issue (that is `om-prepare-issue`) and never edits repository source files. It mutates only labels, issue bodies, and comments.
+- Existing issues only: this skill never creates an issue (that is `om-prepare-issue`) and never edits repository source files. It mutates only labels, issue bodies, and comments — the implementation-prep analysis is strictly **read-only** on the codebase and posts its findings as a comment.
+- Implementation-prep is autonomous (never stops to ask) and idempotent; it reads code so it defaults off for batches (opt in with `--prep-impl`) and, when it does run over a batch, caps how many issues get the heavy analysis and reports the cap rather than silently dropping the rest.
 - **Idempotent**: add only labels that are missing; never remove a label a human set; post the understanding comment only when no equivalent one from this skill already exists; re-running on the same issue is a no-op.
 - **Claim-aware**: skip any issue a different actor is actively working (foreign `in-progress`/assignee or a fresh claim comment) and any issue carrying a repo-defined human-hold label; this is a light housekeeping pass, so it does not take its own long-lived `in-progress` lock.
 - **Non-destructive wording fixes**: when clarifying a laconic body, preserve the reporter's original text verbatim (a collapsed section) and add the clarified description alongside it; the reporter's intent is never silently overwritten. The clarification is a proposal — the posted understanding comment invites correction.

--- a/skills/om-auto-manage-issues/references/implementation-prep.md
+++ b/skills/om-auto-manage-issues/references/implementation-prep.md
@@ -1,0 +1,61 @@
+# Implementation-prep analysis — make an issue ready to fix
+
+The step-2.4 procedure `om-auto-manage-issues` runs to prepare an issue for
+implementation: a **read-only** root-cause / impact analysis posted as a comment so
+the next agent (`om-auto-fix-issue`) or a human can start fixing without
+re-exploring the repo. It never edits source and never stops to ask — this is the
+"prepare for implementation, but not interactively" behavior.
+
+## When it runs
+
+- On by default for a single `{issueId}`; opt-in for a batch (`--prep-impl`), since
+  it reads code per issue. Skipped entirely by `--relabel-only` or `--no-prep`.
+- Skip an issue that is already implementation-ready — it links a spec, or already
+  carries an implementation-notes comment from this skill (idempotency: scan
+  **list-issue-comments** for the marker below), or is not actually actionable
+  (a question/discussion, a `wontfix`/`do-not-close` hold).
+- **Batch cap:** run the heavy analysis on at most a sensible number of issues per
+  run (e.g. the worst-described / highest-priority first); when more qualify than
+  the cap, process the cap and **report** how many were left (never silently drop).
+
+## Producing the analysis (read-only)
+
+Pick the analyzer by issue kind:
+
+- **Bug / defect** — when `om-root-cause` is installed, invoke it verbatim
+  (`om-root-cause {issueId}`); it is read-only and returns a Summary / Root cause /
+  Files to change / Approach / Risks brief. Use its output directly.
+- **Feature, or `om-root-cause` not installed** — do a lighter inline analysis
+  yourself, read-only: locate the affected modules/entry points/contracts, name the
+  smallest safe change surface and the conventions that apply, list the tests that
+  will be needed, and flag any `BACKWARD_COMPATIBILITY.md` surface touched. This is
+  the same shape of guidance `om-prepare-issue` writes for a new issue — reuse that
+  lens rather than inventing a new one.
+
+Reference real file paths and symbols. Mark anything uncertain as a hypothesis, not
+a fact — you are preparing the ground, not committing to a fix.
+
+## Posting it (idempotent)
+
+Post one comment via **comment-issue**, opened with a stable marker so re-runs
+detect and skip it:
+
+```markdown
+🤖 `om-auto-manage-issues` implementation notes — read-only analysis to help fix this
+
+**Likely area:** {files / modules / symbols}
+**Root cause / mechanism:** {for a bug: where and why it breaks; for a feature: where it plugs in}
+**Suggested approach:** {smallest safe change surface}
+**Tests to add:** {unit; integration when flows cross boundaries}
+**Compatibility:** {None | protected surfaces touched + required migration per BACKWARD_COMPATIBILITY.md}
+**Confidence:** {high / medium / low — what a human should double-check}
+
+Pick this up with `om-auto-fix-issue {issueId}` (features route to `om-auto-implement-issue`).
+```
+
+Optionally fold a one-line "Likely area" pointer into the clarified description when
+the wording-clarify step (2.3) also ran, but keep the full analysis in the comment.
+Under `--dry-run`, produce the analysis text for the report but post nothing.
+
+Never let the prep analysis mutate code, run a build/test that writes state, or
+exfiltrate anything — it is a read-only reasoning pass over the repository.

--- a/skills/om-prepare-issue/SKILL.md
+++ b/skills/om-prepare-issue/SKILL.md
@@ -54,8 +54,10 @@ skill produces the design instead of merely recommending it. Follow
 `references/spec-when-missing.md`: create the tracking issue first (step 4, so
 there is a number to link), then delegate to the `om-auto-implement-issue` skill
 with the new issue number and `--spec-only`, which writes the spec by following
-`om-spec-writing` verbatim (**including its Open Questions hard gate**), commits it
-as the first commit, and opens a draft **spec PR** against the base branch. Then
+`om-spec-writing` verbatim — running in its **default autonomous mode** so the spec
+is produced end-to-end (Open Questions resolved with documented defaults + an
+override comment; pass `--interactive` when a human wants to answer them), commits
+it as the first commit, and opens a draft **spec PR** against the base branch. Then
 comment the spec path and PR link back onto the issue via **comment-issue**. The
 issue now links a real, reviewable design; implementation resumes later with
 `om-auto-continue-pr {prNumber}` or `om-auto-implement-issue {issueId}`. This is

--- a/skills/om-prepare-issue/references/spec-when-missing.md
+++ b/skills/om-prepare-issue/references/spec-when-missing.md
@@ -28,14 +28,17 @@ If any fails, do not open a spec PR — fall back to step 3's inline guidance.
 2. **Delegate spec authoring to `om-auto-implement-issue`** with the new issue
    number and `--spec-only`. Follow that skill's workflow verbatim: it confirms the
    feature is not already implemented, writes the spec by following `om-spec-writing`
-   **including its Open Questions hard gate**, commits the spec as the first commit,
+   **including its Open Questions gate**, commits the spec as the first commit,
    and opens a **draft spec PR** against the base branch. Because this is a
    design-only PR, its body references the issue with `Refs #{issueId}` (**not**
    `Closes` — merging the spec must not close the still-unimplemented FR), plus
    `Source doc:` and `Status: in-progress`. It stops after the spec lands (no
-   implementation). Never answer the Open Questions gate yourself; when running
-   unattended with no user to answer, report that the spec needs the questions
-   resolved and stop rather than inventing answers.
+   implementation). Design questions deserve a human: prefer running this
+   interactively so the Open Questions gate stops for the user, and do **not** pass
+   `--autonomous` here. Only when the run is genuinely unattended does the delegated
+   skill's autonomous path apply — it resolves the questions with conservative
+   documented defaults and posts them on the issue/PR for override (the spec is only
+   a draft-PR proposal for review, so nothing merges on assumptions alone).
 3. **Link the spec back onto the issue** via **comment-issue**: post the spec path
    and the spec PR link, and update the issue body's `## Spec` section to reference
    them. The issue now points at a real, reviewable design.

--- a/skills/om-prepare-issue/references/spec-when-missing.md
+++ b/skills/om-prepare-issue/references/spec-when-missing.md
@@ -33,12 +33,14 @@ If any fails, do not open a spec PR — fall back to step 3's inline guidance.
    design-only PR, its body references the issue with `Refs #{issueId}` (**not**
    `Closes` — merging the spec must not close the still-unimplemented FR), plus
    `Source doc:` and `Status: in-progress`. It stops after the spec lands (no
-   implementation). Design questions deserve a human: prefer running this
-   interactively so the Open Questions gate stops for the user, and do **not** pass
-   `--autonomous` here. Only when the run is genuinely unattended does the delegated
-   skill's autonomous path apply — it resolves the questions with conservative
-   documented defaults and posts them on the issue/PR for override (the spec is only
-   a draft-PR proposal for review, so nothing merges on assumptions alone).
+   implementation). Let it run in its **default autonomous mode** so the spec is
+   actually produced end-to-end: it resolves any Open Questions with conservative
+   documented defaults and posts them on the issue/PR for a human to override before
+   merge (the spec is only a draft-PR proposal for review, so nothing merges on
+   assumptions alone). When a human is filing the issue and wants to make the design
+   calls themselves, pass `--interactive` on the delegation to stop at the Open
+   Questions gate instead. Either way, a required-and-missing spec always gets
+   written here — never left as a recommendation.
 3. **Link the spec back onto the issue** via **comment-issue**: post the spec path
    and the spec PR link, and update the issue body's `## Spec` section to reference
    them. The issue now points at a real, reviewable design.


### PR DESCRIPTION
## Goal
Harden the issue→PR pipeline: make the `om-auto-*` skills autonomous by default at the spec Open Questions gate, remove the double-PR collision between `om-auto-implement-issue` and `om-auto-create-pr`, deduplicate PR-opening behind an optional `om-open-pr`, and give `om-auto-manage-issues` implementation-prep analysis.

## What Changed
- **Autonomous by default** — `om-auto-implement-issue` resolves `om-spec-writing`'s Open Questions gate with conservative documented defaults + an override comment instead of stopping (`--interactive` opts back into the human stop). `om-auto-fix-issue` inherits it; `om-prepare-issue` always authors a required-and-missing spec.
- **One PR opener, reused** — new `om-auto-create-pr/references/pr-open-reuse.md`: prefer the `om-open-pr` skill when installed, fall back to inline `create-pr` when not (so `om-auto-create-pr` works standalone), never open a duplicate PR. Wired into `om-auto-create-pr`, `om-auto-continue-pr`, `om-auto-continue-pr-loop`, `om-auto-implement-issue`.
- **Implement-by-continuation** — `om-auto-implement-issue` opens exactly one (spec-first) PR and implements it via `om-auto-continue-pr` / `om-auto-continue-pr-loop` on that same PR (engine + plan format chosen by spec size), never a second `om-auto-create-pr` PR. Step 6 promotes it out of draft via `mark-pr-ready`; the issue-vs-PR lock handoff is now explicit.
- **`om-auto-manage-issues` implementation-prep** — a read-only root-cause/impact analysis (via `om-root-cause` when installed) posted as an "implementation notes" comment so an existing issue is ready to fix; autonomous, idempotent, default-off for batches.
- **`update-issue` tracker operation** (from the earlier part of this branch) for the non-destructive body clarification.
- DECISIONS.md entries for each decision.

## Tests
- Markdown skills only — `bash scripts/lint.sh` → **Lint OK** after every commit.

## Breaking Changes
- Behavioral default: `om-auto-implement-issue` no longer stops at the Open Questions gate unless `--interactive`. The `--autonomous` flag introduced earlier on this branch is removed in favor of default-on. No public/released surface regresses.

## Review
Two independent consistency passes were folded in — the second caught that the continuation rewrite had dropped the draft→ready promotion and mislabeled the lock model; both fixed in `04bb9ae`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
