### PR TITLE
feat(om-auto-implement-issue): verify UI + attach screenshots at end of run

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -83,6 +83,14 @@ where a person wants to make the design calls. Progress beats stalling, as long 
 every assumption is surfaced and reversible and nothing merges on assumptions
 alone.
 
+A user-facing FR also ends with UI proof: `om-auto-implement-issue` runs
+`om-auto-verify-pr-ui` (evidence-only) after implementation, so a real-browser
+pass/fail report and screenshots land as a PR comment via `attach-image-evidence`.
+It stays evidence-only — screenshots for the reviewer, `needs-qa` kept, never a
+self-granted `qa-approved` — and is skipped for non-UI FRs, `--no-ui`, or when no
+runnable UI surface exists. A UI-verify that cannot run is noted, not fatal: the PR
+is still implemented and reviewed.
+
 ## Issue skills split: create vs manage
 
 `om-prepare-issue` conflated two jobs — filing a *new* issue and improving

--- a/skills/om-auto-implement-issue/SKILL.md
+++ b/skills/om-auto-implement-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: om-auto-implement-issue
-description: Implement a new feature-request (FR) tracker issue end to end by combining spec-writing and auto-create-pr — first land a spec on a PR, then implement it on the same branch. Confirms the feature is not already built (never a bug-confirmation gate), writes or reuses a spec, commits it as the first commit, opens a draft PR, then delivers the spec phase-by-phase with the validation gate, labels, and the autofix review loop. Autonomous by default: at spec-writing's Open Questions gate it applies conservative documented defaults and posts them for override instead of stopping (pass --interactive to stop for a human). Use when the user says "implement issue 123 as a feature", "build the FR in #123", "spec-then-build this feature request".
+description: Implement a new feature-request (FR) tracker issue end to end by combining spec-writing and auto-create-pr — first land a spec on a PR, then implement it on the same branch. Confirms the feature is not already built (never a bug-confirmation gate), writes or reuses a spec, commits it as the first commit, opens a draft PR, then delivers the spec phase-by-phase with the validation gate, labels, and the autofix review loop. Autonomous by default: at spec-writing's Open Questions gate it applies conservative documented defaults and posts them for override instead of stopping (pass --interactive to stop for a human). When the change is user-facing it finishes by running om-auto-verify-pr-ui to QA the UI in a real browser and post screenshots as a PR comment (skip with --no-ui). Use when the user says "implement issue 123 as a feature", "build the FR in #123", "spec-then-build this feature request".
 ---
 
 # Auto Implement Issue (FR → spec → PR → implementation)
@@ -26,6 +26,7 @@ with no tracker issue, use `om-auto-create-pr` directly; for a defect, use
 - `--spec-only` (optional) — stop after the spec lands on the PR; leave implementation to a later `om-auto-continue-pr {prNumber}` run (spec-reviewed-first workflow)
 - `--interactive` (optional) — opt into human gates. This `om-auto-*` skill runs **autonomously by default**: when `om-spec-writing`'s Open Questions gate would block, it resolves each question with a conservative documented default and continues, posting the questions + applied defaults as an issue/PR comment for later override (see `references/autonomous-open-questions.md`). Pass `--interactive` to instead **stop** at the gate and wait for a human to answer — use it when a person is driving the run and wants to make the design calls.
 - `--slug <kebab-case>` (optional) — override the slug used in the branch, plan, and spec filenames
+- `--no-ui` (optional) — skip the end-of-run UI verification (step 7) even when the change looks user-facing; use when there is no runnable UI surface
 - `--force` (optional) — bypass the in-progress / claim-conflict check when a previous run or another actor left a lock, branch, or plan behind
 
 ## Step 0 — Load config and context
@@ -43,8 +44,8 @@ missing descriptor triggers the same setup run); it also resolves `BASE_BRANCH`
 `$TRACKER_FILE`; every tracker operation named in this skill (**current-user**,
 **get-issue**, **comment-issue**, **assign-issue** / **unassign-issue**,
 **search-prs**, **search-issues**, **create-pr**, **comment-pr**,
-**mark-pr-ready**, …) executes as that descriptor defines, and the label guards
-come from it.
+**mark-pr-ready**, **get-pr-diff** / **get-pr-files**, **attach-image-evidence**,
+…) executes as that descriptor defines, and the label guards come from it.
 
 Right after loading the config, check for a repo-local skill of the same name at
 `.ai/skills/om-auto-implement-issue/SKILL.md`; when present, apply it as a
@@ -166,22 +167,44 @@ already holds the PR lock; either is expected (like `om-auto-create-pr` handing 
 promote the PR out of draft — `om-open-pr` opens it as a draft and leaves promotion
 to the ready state to step 6 here. `--spec-only` runs never reach this step.
 
-### 6. Mark ready, release, report
+### 6. Mark ready
 
 Once the continuation reports the PR `complete`, **promote the PR out of draft via
 the tracker operation mark-pr-ready** — the continuation flips the body `Status:`
 text to `complete` but never leaves draft, and `om-open-pr` opened it as a draft, so
 this is the step that makes it a ready-for-review PR. Keep it a **draft** only when
 the run is `--spec-only` (design-only) or an autonomous default was flagged
-`⚠ NEEDS HUMAN CONFIRMATION` (keep `needs-qa`, never `qa-approved`). If the run
-aborts before the PR opened (i.e. before step 4 handed the issue back), release the
-issue `in-progress` lock in the `trap`/finally with an abort comment, exactly as
-`om-auto-fix-issue` step 8 does; after the PR is open the continuation owns the PR
-lock and its own release. Confirm the summary comment the continuation posted names
-the FR number and the spec path; if the run was `--spec-only` (no implementation),
-post the summary yourself per the `om-auto-create-pr` step-12 template. Clean up any
-worktree this run created, record `PR: #{n}` in the plan, and report: issue, spec
-path, branch, PR URL, and
+`⚠ NEEDS HUMAN CONFIRMATION` (keep `needs-qa`, never `qa-approved`).
+
+### 7. Verify the UI and attach screenshots
+
+When the implemented change touches a **user-facing surface** — and the run is not
+`--spec-only` and not docs-only — verify it in a real browser and leave the
+evidence on the PR. Run `om-auto-verify-pr-ui {prNumber}` (autonomous, its default
+**evidence-only** mode): it boots the app, drives the changed UI flow, captures
+screenshots, and posts them **as a PR comment** with a pass/fail report through the
+tracker's **attach-image-evidence** operation. Because this is user-facing feature
+work, ensure the PR carries `needs-qa`; this skill never adds `qa-approved` or
+`qa-self-verified` (a human or an explicit self-QA sign-off owns those). Decide
+"user-facing" from the diff (routes, components, templates, styles, user-visible
+copy) via **get-pr-diff** / **get-pr-files**; for a purely backend/API/docs FR,
+skip this step and note `UI: n/a` in the report. Skip with a noted reason when
+`--no-ui` was passed or no runnable UI surface exists. If `om-auto-verify-pr-ui`
+cannot run (no test environment, checks not green), note it and continue rather
+than failing the whole run — the PR is still implemented and reviewed.
+
+### 8. Release, report
+
+If the run aborts before the PR opened (i.e. before step 4 handed the issue back),
+release the issue `in-progress` lock in the `trap`/finally with an abort comment,
+exactly as `om-auto-fix-issue` step 8 does; after the PR is open the continuation
+owns the PR lock and its own release (and `om-auto-verify-pr-ui` owns the claim it
+takes for QA). Confirm the summary comment the continuation posted names the FR
+number and the spec path, and that the UI screenshots/report from step 7 are on the
+PR; if the run was `--spec-only` (no implementation), post the summary yourself per
+the `om-auto-create-pr` step-12 template. Clean up any worktree this run created,
+record `PR: #{n}` in the plan, and report: issue, spec path, branch, PR URL, UI
+verification outcome, and
 `{complete | spec-only — use om-auto-continue-pr <n> | in-progress}`.
 
 ## Rules
@@ -191,6 +214,7 @@ path, branch, PR URL, and
 - Spec first, always: the spec is the first commit and is visible on the PR before implementation. Autonomous by default — do not stop at `om-spec-writing`'s Open Questions gate; apply conservative documented defaults and post them as an issue/PR comment for override (`references/autonomous-open-questions.md`), keeping the PR draft / `needs-qa` when any default is high-stakes. Only `--interactive` turns the gate into a hard stop for a human, in which case never answer your own gate questions.
 - Reuse, don't reinvent, and **never open a second PR**: this skill opens exactly one PR (the spec-first PR in step 4) and implements it as a **continuation** via `om-auto-continue-pr` / `om-auto-continue-pr-loop` (chosen per `references/implementation-engine-selection.md`) — which reuse `om-auto-create-pr`'s implement/validate/review/label/summary machinery on the existing PR rather than opening a fresh one. The design comes from `om-spec-writing`; PR opening/labeling follows `om-auto-create-pr/references/pr-open-reuse.md` (prefer `om-open-pr` when installed, inline otherwise). This skill only adds FR triage, spec-first ordering, engine selection, and issue linkage.
 - Every code change ships with tests; docs-only FRs still run the configured lint/check. Run the full `validation.commands` gate before marking the PR ready unless a real blocker prevents it — then document it.
+- A user-facing FR ends with UI verification: run `om-auto-verify-pr-ui {prNumber}` (evidence-only) so screenshots + a pass/fail report land as a PR comment via **attach-image-evidence**; keep `needs-qa`, never add `qa-approved`/`qa-self-verified`. Skip only for non-UI FRs (`UI: n/a`), `--no-ui`, or when no runnable UI surface exists; a UI-verify that cannot run is noted, not fatal.
 - The base branch always comes from config (`baseBranch`); never hard-code it. All tracker interaction goes through named operations via the descriptor.
 - Two distinct locks, cleanly handed off: step 4 claims the **issue** (three-signal), and opening the PR hands the issue back and releases that issue lock (`om-open-pr` does this; on the inline path, release it at PR-open too). From PR-open onward the **PR** lock is owned by the continuation (or, on `--spec-only`, the PR itself is the resume handle for `om-auto-continue-pr {prNumber}`). A crash **before** the PR opens releases the issue lock in the `trap`; after PR-open the continuation owns releasing the PR lock. Never leak a lock or a worktree, and never `mark-pr-ready` a `--spec-only` design PR or one gated on a `⚠ NEEDS HUMAN CONFIRMATION` default.
 - The linkage line matches what the PR ships: an **implementing** PR carries `Closes #{issueId}` so the FR auto-closes on merge; a **`--spec-only` design PR** carries `Refs #{issueId}` (no closing keyword) so merging the spec leaves the FR open for implementation. The PR body always carries `Source doc:` and `Tracking plan:` so `om-auto-continue-pr` can resume. Never add `qa-approved` from this skill.

--- a/skills/om-auto-implement-issue/SKILL.md
+++ b/skills/om-auto-implement-issue/SKILL.md
@@ -42,8 +42,9 @@ missing descriptor triggers the same setup run); it also resolves `BASE_BRANCH`
 `QA_GATE`, and the `validation.commands` used by the implementation half. Read
 `$TRACKER_FILE`; every tracker operation named in this skill (**current-user**,
 **get-issue**, **comment-issue**, **assign-issue** / **unassign-issue**,
-**search-prs**, **search-issues**, **create-pr**, **comment-pr**, …) executes as
-that descriptor defines, and the label guards come from it.
+**search-prs**, **search-issues**, **create-pr**, **comment-pr**,
+**mark-pr-ready**, …) executes as that descriptor defines, and the label guards
+come from it.
 
 Right after loading the config, check for a repo-local skill of the same name at
 `.ai/skills/om-auto-implement-issue/SKILL.md`; when present, apply it as a
@@ -155,19 +156,32 @@ duplicate. Choose the engine per `references/implementation-engine-selection.md`
 Before handing off, make sure the PR body carries the implementing-PR linkage from
 `references/pr-linkage.md` — `Closes #{issueId}` (so the merge auto-closes the FR),
 `Source doc:`, `Tracking plan:` — and the `feature` category label, so the
-continuation preserves them. The continuation owns marking the PR ready, the review
-loop, labels, and the summary comment from here (it holds the `in-progress` lock as
-re-entry under the same owner). `--spec-only` runs never reach this step.
+continuation preserves them. The continuation runs the implement → validate →
+`om-auto-review-pr` loop → labels → `Status: complete` → summary machinery on the
+existing PR. Claim/lock note: step 4 opened the PR (which, via `om-open-pr`, hands
+the issue back and releases the **issue** `in-progress` lock), so the continuation
+claims the **PR** itself — freshly when unclaimed, or as re-entry when the same user
+already holds the PR lock; either is expected (like `om-auto-create-pr` handing to
+`om-auto-review-pr`), not a conflict. What the continuation does **not** do is
+promote the PR out of draft — `om-open-pr` opens it as a draft and leaves promotion
+to the ready state to step 6 here. `--spec-only` runs never reach this step.
 
-### 6. Release, report
+### 6. Mark ready, release, report
 
-Once the continuation reports the PR complete (or if the run aborts after step 4's
-claim, release the `in-progress` lock in the `trap`/finally with an abort comment,
-exactly as `om-auto-fix-issue` step 8 does). Confirm the summary comment the
-continuation posted names the FR number and the spec path; if the run was
-`--spec-only` (no implementation), post the summary yourself per the
-`om-auto-create-pr` step-12 template. Clean up any worktree this run created, record
-`PR: #{n}` in the plan, and report: issue, spec path, branch, PR URL, and
+Once the continuation reports the PR `complete`, **promote the PR out of draft via
+the tracker operation mark-pr-ready** — the continuation flips the body `Status:`
+text to `complete` but never leaves draft, and `om-open-pr` opened it as a draft, so
+this is the step that makes it a ready-for-review PR. Keep it a **draft** only when
+the run is `--spec-only` (design-only) or an autonomous default was flagged
+`⚠ NEEDS HUMAN CONFIRMATION` (keep `needs-qa`, never `qa-approved`). If the run
+aborts before the PR opened (i.e. before step 4 handed the issue back), release the
+issue `in-progress` lock in the `trap`/finally with an abort comment, exactly as
+`om-auto-fix-issue` step 8 does; after the PR is open the continuation owns the PR
+lock and its own release. Confirm the summary comment the continuation posted names
+the FR number and the spec path; if the run was `--spec-only` (no implementation),
+post the summary yourself per the `om-auto-create-pr` step-12 template. Clean up any
+worktree this run created, record `PR: #{n}` in the plan, and report: issue, spec
+path, branch, PR URL, and
 `{complete | spec-only — use om-auto-continue-pr <n> | in-progress}`.
 
 ## Rules
@@ -178,5 +192,5 @@ continuation posted names the FR number and the spec path; if the run was
 - Reuse, don't reinvent, and **never open a second PR**: this skill opens exactly one PR (the spec-first PR in step 4) and implements it as a **continuation** via `om-auto-continue-pr` / `om-auto-continue-pr-loop` (chosen per `references/implementation-engine-selection.md`) — which reuse `om-auto-create-pr`'s implement/validate/review/label/summary machinery on the existing PR rather than opening a fresh one. The design comes from `om-spec-writing`; PR opening/labeling follows `om-auto-create-pr/references/pr-open-reuse.md` (prefer `om-open-pr` when installed, inline otherwise). This skill only adds FR triage, spec-first ordering, engine selection, and issue linkage.
 - Every code change ships with tests; docs-only FRs still run the configured lint/check. Run the full `validation.commands` gate before marking the PR ready unless a real blocker prevents it — then document it.
 - The base branch always comes from config (`baseBranch`); never hard-code it. All tracker interaction goes through named operations via the descriptor.
-- Claim through the three-signal protocol; release the `in-progress` lock when the run reaches a terminal state (on success once the PR is ready, or in the failure `trap` on any abort) — a crashed run must never leak a lock or a worktree. The one exception is a `--spec-only` hand-off, which deliberately **retains** the lock as the resume marker for `om-auto-continue-pr` (the resuming run releases it); a hand-off is not a leak.
+- Two distinct locks, cleanly handed off: step 4 claims the **issue** (three-signal), and opening the PR hands the issue back and releases that issue lock (`om-open-pr` does this; on the inline path, release it at PR-open too). From PR-open onward the **PR** lock is owned by the continuation (or, on `--spec-only`, the PR itself is the resume handle for `om-auto-continue-pr {prNumber}`). A crash **before** the PR opens releases the issue lock in the `trap`; after PR-open the continuation owns releasing the PR lock. Never leak a lock or a worktree, and never `mark-pr-ready` a `--spec-only` design PR or one gated on a `⚠ NEEDS HUMAN CONFIRMATION` default.
 - The linkage line matches what the PR ships: an **implementing** PR carries `Closes #{issueId}` so the FR auto-closes on merge; a **`--spec-only` design PR** carries `Refs #{issueId}` (no closing keyword) so merging the spec leaves the FR open for implementation. The PR body always carries `Source doc:` and `Tracking plan:` so `om-auto-continue-pr` can resume. Never add `qa-approved` from this skill.

--- a/skills/om-auto-implement-issue/references/pr-linkage.md
+++ b/skills/om-auto-implement-issue/references/pr-linkage.md
@@ -53,10 +53,12 @@ See the Progress section in the tracking plan.
 
 Open the PR as a **draft** in step 4 (spec only, no implementation yet). On a full
 run, the same PR becomes the implementing PR, so it carries `Closes #{issueId}`
-from the start; flip it out of draft (**mark-pr-ready**) and change `Status:` to
-`complete` in step 6 once every Progress step is checked, keeping the `Closes`
-line intact (removing it breaks auto-close). On a `--spec-only` run the draft PR
-carries `Refs #{issueId}` and stays a design PR — the FR closes later, when the
+from the start. During implementation the continuation (`om-auto-continue-pr` /
+`-loop`) changes the body `Status:` to `complete` once every Progress step is
+checked; then **step 6 of this skill promotes the PR out of draft via
+mark-pr-ready** (the continuation does not leave draft). Keep the `Closes` line
+intact throughout (removing it breaks auto-close). On a `--spec-only` run the draft
+PR carries `Refs #{issueId}` and stays a design PR — the FR closes later, when the
 implementing PR merges.
 
 ## Labels

--- a/skills/om-auto-implement-issue/references/spec-first-flow.md
+++ b/skills/om-auto-implement-issue/references/spec-first-flow.md
@@ -83,11 +83,12 @@ the `feature` category label plus one priority and one risk label (skip
 `needs-qa`/`skip-qa` — there is no behavior to QA yet), and post the label
 rationale comments.
 
-Lock handoff on the `--spec-only` stop: this is a deliberate hand-off, not a
-crash, so the run intentionally **keeps** the `in-progress` label and assignee and
-leaves a `🤖` comment stating the spec is ready and implementation resumes with
+Lock handoff on the `--spec-only` stop: the **PR** is the resume handle, not the
+issue lock. Opening the PR hands the issue back and releases its `in-progress` lock
+(`om-open-pr` does this; do the same on the inline path), and you leave a `🤖`
+comment on the issue/PR stating the spec is ready and implementation resumes with
 `om-auto-continue-pr {prNumber}` (or `om-auto-implement-issue {issueId}`, which
-reuses the merged spec). This retained lock is the resume marker, not a leak — the
-resuming run owns releasing it. (Contrast the failure `trap`, which *does* release
-the lock, because an aborted run is not a hand-off.) Otherwise continue to body
-step 5 (implement).
+reuses the spec). The draft PR carrying `Tracking plan:` / `Source doc:` is what a
+resume keys on. (Contrast the failure `trap` before the PR opens, which releases the
+issue lock because an aborted run left no PR to resume from.) Otherwise continue to
+body step 5 (implement).


### PR DESCRIPTION
## Goal
Extend `om-auto-implement-issue` to close the loop with UI proof: after a user-facing FR is implemented, run `om-auto-verify-pr-ui` to QA the UI in a real browser and **attach the screenshots as a PR comment**.

## What Changed
- **New step 7 "Verify the UI and attach screenshots"** — for a user-facing FR (decided from the diff via `get-pr-diff`/`get-pr-files`), run `om-auto-verify-pr-ui {prNumber}` in its default evidence-only mode: it boots the app, drives the changed flow, and posts screenshots + a pass/fail report **as a PR comment** through `attach-image-evidence`. Keeps `needs-qa`; never self-grants `qa-approved`/`qa-self-verified`.
- **`--no-ui`** flag to skip it; non-UI/backend/docs FRs note `UI: n/a`; a UI-verify that cannot run (no test env, checks not green) is noted, not fatal.
- Step 6 split into `6. Mark ready` → `7. Verify UI` → `8. Release, report`; description, tracker-op list (`get-pr-diff`/`get-pr-files`/`attach-image-evidence`), Rules, and DECISIONS updated.

## Re-included fix
This branch also carries the `mark-pr-ready` + issue-vs-PR lock-model review fixes (`04bb9ae`) that landed on the #28 branch **after** #28 merged, so were missing from `main`.

## Tests
- Markdown skills only — `bash scripts/lint.sh` → **Lint OK**.

## Breaking Changes
- None — additive. UI verification is gated on user-facing changes and skippable; it reuses the existing `om-auto-verify-pr-ui` skill and `attach-image-evidence` tracker operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
