### PR TITLE
feat(implement-spec): default to plain engine, gate loop behind >20 steps or --loop

### DIFF
--- a/.ai/runs/2026-07-22-engine-selection-default-plain.md
+++ b/.ai/runs/2026-07-22-engine-selection-default-plain.md
@@ -37,17 +37,19 @@
 
 ## Progress
 
+PR: #47
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Core rule
 
-- [ ] 1.1 Rewrite engine-selection.md with the deterministic plain-default rule
-- [ ] 1.2 Add --loop and align om-auto-implement-spec SKILL.md step 2
+- [x] 1.1 Rewrite engine-selection.md with the deterministic plain-default rule — 86011f3
+- [x] 1.2 Add --loop and align om-auto-implement-spec SKILL.md step 2 — 86011f3
 
 ### Phase 2: Consumer alignment
 
-- [ ] 2.1 Align om-auto-fix-issue arguments and feature-route wording
+- [x] 2.1 Align om-auto-fix-issue arguments and feature-route wording — b4c1665
 
 ### Phase 3: Gate
 
-- [ ] 3.1 Lint gate + self-review
+- [x] 3.1 Lint gate + self-review — b4c1665

--- a/.ai/runs/2026-07-22-engine-selection-default-plain.md
+++ b/.ai/runs/2026-07-22-engine-selection-default-plain.md
@@ -1,0 +1,53 @@
+# Execution plan: default the implementation engine to plain, gate the loop behind >20 steps or --loop
+
+## Goal
+
+`om-auto-implement-spec` (and the chains that route through it) should pick the cheap plain engines (`om-auto-create-pr` / `om-auto-continue-pr`) by default. The expensive loop engines (`om-auto-create-pr-loop` / `om-auto-continue-pr-loop`) are selected only when the spec's implementation plan has **more than 20 steps** or the caller explicitly passes a new **`--loop`** flag.
+
+## Scope
+
+- `skills/om-auto-implement-spec/references/engine-selection.md` — replace the fuzzy "roughly >8–10 phases/steps, UI work, unlikely to finish in one pass" heuristic with the deterministic rule: plain unless total Steps > 20 or `--loop`.
+- `skills/om-auto-implement-spec/SKILL.md` — add the `--loop` argument; align step 2 (both engine branches) and the Chaining note with the new rule.
+- `skills/om-auto-fix-issue/SKILL.md` + `references/feature-route.md` — the feature route delegates to `om-auto-implement-spec` and restates the loop criteria; align the wording and pass `--loop` through.
+
+## Non-goals
+
+- No behavior change inside the four engine skills themselves.
+- No change to the loop skills' internal Simple-run/Spec-implementation-run classification.
+- No tracker descriptor changes.
+
+## Risks
+
+- Consumers outside this repo may cite the old ">8–10" heuristic in local overrides; the rule change is documented in the PR body (no UPGRADE_NOTES entry — no descriptor/config contract changes).
+
+## Implementation Plan
+
+### Phase 1: Core rule
+
+- 1.1 Rewrite `engine-selection.md`: plain engine is the default; loop only when the plan's total Step count exceeds 20 or `--loop` was passed; keep the create-vs-continue axis unchanged.
+- 1.2 Update `om-auto-implement-spec/SKILL.md`: add `--loop` to Arguments, rewrite step 2's engine-choice wording on both branches, fix the Chaining parenthetical.
+
+### Phase 2: Consumer alignment
+
+- 2.1 Update `om-auto-fix-issue`: `--loop` pass-through in Arguments, feature-route.md wording aligned to the new rule.
+
+### Phase 3: Gate
+
+- 3.1 Run `bash scripts/lint.sh`, self-review the diff, fix findings.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Core rule
+
+- [ ] 1.1 Rewrite engine-selection.md with the deterministic plain-default rule
+- [ ] 1.2 Add --loop and align om-auto-implement-spec SKILL.md step 2
+
+### Phase 2: Consumer alignment
+
+- [ ] 2.1 Align om-auto-fix-issue arguments and feature-route wording
+
+### Phase 3: Gate
+
+- [ ] 3.1 Lint gate + self-review

--- a/skills/om-auto-fix-issue/SKILL.md
+++ b/skills/om-auto-fix-issue/SKILL.md
@@ -14,7 +14,6 @@ Take a tracker issue end to end without disturbing the user's active worktree. T
 - `--interactive` (optional, feature route) — opt into human gates: the spec is written with `om-spec-writing`'s interactive Open Questions hard stop instead of `--autonomous` defaults. Default is fully autonomous (defaults applied and posted for override).
 - `--slug <kebab-case>` (optional, feature route) — override the derived slug (passed through to the delegated skills)
 - `--no-ui` (optional) — skip UI verification (bug route: skip step 10; feature route: passed through) — for example, to save resources
-- `--loop` (optional, feature route) — passed through to `om-auto-implement-spec`: force the loop engine; without it the loop is used only for a >20-Step plan
 - `--force` (optional) — bypass the in-progress concurrency check; use only when intentionally taking over an issue another actor already claimed
 
 ## Chaining

--- a/skills/om-auto-fix-issue/SKILL.md
+++ b/skills/om-auto-fix-issue/SKILL.md
@@ -14,6 +14,7 @@ Take a tracker issue end to end without disturbing the user's active worktree. T
 - `--interactive` (optional, feature route) — opt into human gates: the spec is written with `om-spec-writing`'s interactive Open Questions hard stop instead of `--autonomous` defaults. Default is fully autonomous (defaults applied and posted for override).
 - `--slug <kebab-case>` (optional, feature route) — override the derived slug (passed through to the delegated skills)
 - `--no-ui` (optional) — skip UI verification (bug route: skip step 10; feature route: passed through) — for example, to save resources
+- `--loop` (optional, feature route) — forwarded verbatim to `om-auto-implement-spec` **only when the user passed it to this skill**; the route never adds it on its own. Without it the loop engine is selected solely by the >20-Step rule.
 - `--force` (optional) — bypass the in-progress concurrency check; use only when intentionally taking over an issue another actor already claimed
 
 ## Chaining

--- a/skills/om-auto-fix-issue/SKILL.md
+++ b/skills/om-auto-fix-issue/SKILL.md
@@ -14,6 +14,7 @@ Take a tracker issue end to end without disturbing the user's active worktree. T
 - `--interactive` (optional, feature route) — opt into human gates: the spec is written with `om-spec-writing`'s interactive Open Questions hard stop instead of `--autonomous` defaults. Default is fully autonomous (defaults applied and posted for override).
 - `--slug <kebab-case>` (optional, feature route) — override the derived slug (passed through to the delegated skills)
 - `--no-ui` (optional) — skip UI verification (bug route: skip step 10; feature route: passed through) — for example, to save resources
+- `--loop` (optional, feature route) — passed through to `om-auto-implement-spec`: force the loop engine; without it the loop is used only for a >20-Step plan
 - `--force` (optional) — bypass the in-progress concurrency check; use only when intentionally taking over an issue another actor already claimed
 
 ## Chaining

--- a/skills/om-auto-fix-issue/references/feature-route.md
+++ b/skills/om-auto-fix-issue/references/feature-route.md
@@ -32,10 +32,11 @@ a. **Resolve the spec** — follow the spec-resolution procedure in
    id (checks `$SPECS_DIR` links in the issue body, name matches on the issue title,
    and open spec-PR branches).
 b. **Spec found** (a path, or the spec-only `SPEC_PR` from F2) → invoke
-   **`om-auto-implement-spec {SPEC_PATH-or-SPEC_PR} [--no-ui] [--force]`** verbatim.
-   Never pass `--loop` from this route — the plain engines are the default; the loop
-   variants are selected only by `om-auto-implement-spec`'s own >20-Step rule
-   (`om-auto-implement-spec`'s engine selection). It reuses the spec PR's branch when
+   **`om-auto-implement-spec {SPEC_PATH-or-SPEC_PR} [--no-ui] [--loop] [--force]`** verbatim.
+   Include `--loop` **only when the user passed it to `om-auto-fix-issue`** — never
+   add it on your own; without it the plain engines are the default and the loop
+   variants are selected solely by `om-auto-implement-spec`'s >20-Step rule
+   (its engine selection). It reuses the spec PR's branch when
    one exists (never a second PR), runs the review autofix loop and UI verification
    with screenshots, and leaves a ready PR. Ensure the implementing PR body carries
    `Closes #{issueId}` so the merge auto-closes the issue.

--- a/skills/om-auto-fix-issue/references/feature-route.md
+++ b/skills/om-auto-fix-issue/references/feature-route.md
@@ -32,12 +32,12 @@ a. **Resolve the spec** — follow the spec-resolution procedure in
    id (checks `$SPECS_DIR` links in the issue body, name matches on the issue title,
    and open spec-PR branches).
 b. **Spec found** (a path, or the spec-only `SPEC_PR` from F2) → invoke
-   **`om-auto-implement-spec {SPEC_PATH-or-SPEC_PR} [--no-ui] [--loop] [--force]`** verbatim.
-   It reuses the spec PR's branch when one exists (never a second PR), implements via
-   the continue/create engines (plain by default; the loop variants only on `--loop`
-   or a >20-Step plan, per `om-auto-implement-spec`'s engine selection), runs the
-   review autofix loop and UI verification with
-   screenshots, and leaves a ready PR. Ensure the implementing PR body carries
+   **`om-auto-implement-spec {SPEC_PATH-or-SPEC_PR} [--no-ui] [--force]`** verbatim.
+   Never pass `--loop` from this route — the plain engines are the default; the loop
+   variants are selected only by `om-auto-implement-spec`'s own >20-Step rule
+   (`om-auto-implement-spec`'s engine selection). It reuses the spec PR's branch when
+   one exists (never a second PR), runs the review autofix loop and UI verification
+   with screenshots, and leaves a ready PR. Ensure the implementing PR body carries
    `Closes #{issueId}` so the merge auto-closes the issue.
 c. **No spec** → invoke **`om-auto-write-spec {issueId} [--slug …] [--force]`**
    verbatim (run its spec-writing step interactively when `--interactive` was

--- a/skills/om-auto-fix-issue/references/feature-route.md
+++ b/skills/om-auto-fix-issue/references/feature-route.md
@@ -32,10 +32,11 @@ a. **Resolve the spec** — follow the spec-resolution procedure in
    id (checks `$SPECS_DIR` links in the issue body, name matches on the issue title,
    and open spec-PR branches).
 b. **Spec found** (a path, or the spec-only `SPEC_PR` from F2) → invoke
-   **`om-auto-implement-spec {SPEC_PATH-or-SPEC_PR} [--no-ui] [--force]`** verbatim.
+   **`om-auto-implement-spec {SPEC_PATH-or-SPEC_PR} [--no-ui] [--loop] [--force]`** verbatim.
    It reuses the spec PR's branch when one exists (never a second PR), implements via
-   the continue/create engines (the loop variants for long, many-step specs, per
-   `om-auto-implement-spec`'s engine selection), runs the review autofix loop and UI verification with
+   the continue/create engines (plain by default; the loop variants only on `--loop`
+   or a >20-Step plan, per `om-auto-implement-spec`'s engine selection), runs the
+   review autofix loop and UI verification with
    screenshots, and leaves a ready PR. Ensure the implementing PR body carries
    `Closes #{issueId}` so the merge auto-closes the issue.
 c. **No spec** → invoke **`om-auto-write-spec {issueId} [--slug …] [--force]`**

--- a/skills/om-auto-implement-spec/SKILL.md
+++ b/skills/om-auto-implement-spec/SKILL.md
@@ -12,11 +12,12 @@ Run unattended: the user starts you with a spec reference and comes back to an *
 - `{spec}` (required) — the spec to implement: a repo-relative path, a spec name/slug, an issue id whose body links a spec, or a spec-PR number
 - `{repo}` (optional) — `owner/name`; infer from git remote if omitted
 - `--no-ui` (optional) — skip end-of-run UI verification even when the change is user-facing
+- `--loop` (optional) — force the loop engine (`om-auto-create-pr-loop` / `om-auto-continue-pr-loop`). Without it the loop is selected only when the plan exceeds 20 Steps (`references/engine-selection.md`).
 - `--force` (optional) — bypass claim-conflict checks (passed through to the engine skill)
 
 ## Chaining
 
-A previous skill (typically `om-auto-write-spec`) may already have opened the spec PR — this skill **continues on that branch and PR**, never opening a second one. Downstream, it ends with the `PR:` / `Spec:` reference lines. Companion skills: `om-auto-create-pr` (required engine for fresh runs), `om-auto-continue-pr` (engine when a PR exists; `-loop` for very large specs), `om-auto-review-pr`, `om-auto-qa-pr`, `om-open-pr` — each optional pieces fall back per the shared open-or-reuse contract in `references/pr-finalize.md`.
+A previous skill (typically `om-auto-write-spec`) may already have opened the spec PR — this skill **continues on that branch and PR**, never opening a second one. Downstream, it ends with the `PR:` / `Spec:` reference lines. Companion skills: `om-auto-create-pr` (required engine for fresh runs), `om-auto-continue-pr` (engine when a PR exists; `-loop` only on `--loop` or a >20-Step plan), `om-auto-review-pr`, `om-auto-qa-pr`, `om-open-pr` — each optional pieces fall back per the shared open-or-reuse contract in `references/pr-finalize.md`.
 
 ## Workflow
 
@@ -29,8 +30,8 @@ A previous skill (typically `om-auto-write-spec`) may already have opened the sp
 
 2. **Choose the engine and implement.**
 
-   - **A spec PR exists** (`SPEC_PR` set — e.g. from `om-auto-write-spec`): implement as a **continuation of that PR**. Draft the execution plan from the spec's Implementation Plan (Phases → Steps) exactly as `om-auto-create-pr`'s plan-drafting step does, with `Source doc: ${SPEC_PATH}`, commit it to the PR branch, then invoke `om-auto-continue-pr {SPEC_PR}` verbatim (or `om-auto-continue-pr-loop` for a large spec — choose per `references/engine-selection.md`, and match the plan format to the engine). Never open a second PR.
-   - **No PR yet**: choose the create engine by spec size per `references/engine-selection.md` — `om-auto-create-pr` for an ordinary spec, **`om-auto-create-pr-loop` for a large, many-step spec** (many phases/steps, roughly >8–10; UI work needing screenshots; unlikely to finish in one pass). Invoke the chosen engine verbatim with the brief "Implement the spec at ${SPEC_PATH}" and `--spec ${SPEC_PATH}` — it resolves the plan from the spec's Implementation Plan, uses branch `feat/${SLUG}`, opens the PR ready-for-review via `om-open-pr`/inline with full labels, runs the validation gate, the self-reviews, and the `om-auto-review-pr` autofix loop, and posts the summary comment (the loop engine additionally writes its run folder and checkpoints, resumable via `om-auto-continue-pr-loop`).
+   - **A spec PR exists** (`SPEC_PR` set — e.g. from `om-auto-write-spec`): implement as a **continuation of that PR**. Draft the execution plan from the spec's Implementation Plan (Phases → Steps) exactly as `om-auto-create-pr`'s plan-drafting step does, with `Source doc: ${SPEC_PATH}`, commit it to the PR branch, then invoke `om-auto-continue-pr {SPEC_PR}` verbatim — the default engine. Use `om-auto-continue-pr-loop` only when `--loop` was passed or the plan exceeds 20 Steps (`references/engine-selection.md`; match the plan format to the engine). Never open a second PR.
+   - **No PR yet**: `om-auto-create-pr` is the default engine; use **`om-auto-create-pr-loop` only when `--loop` was passed or the spec's Implementation Plan exceeds 20 Steps** (`references/engine-selection.md`). Invoke the chosen engine verbatim with the brief "Implement the spec at ${SPEC_PATH}" and `--spec ${SPEC_PATH}` — it resolves the plan from the spec's Implementation Plan, uses branch `feat/${SLUG}`, opens the PR ready-for-review via `om-open-pr`/inline with full labels, runs the validation gate, the self-reviews, and the `om-auto-review-pr` autofix loop, and posts the summary comment (the loop engine additionally writes its run folder and checkpoints, resumable via `om-auto-continue-pr-loop`).
 
    Either way the engine owns: worktree isolation, incremental commits, validation gate, labels, review loop, summary comment. Pass `--force` through when given. When `ISSUE_ID` is known, make sure the PR body carries `Closes #${ISSUE_ID}` (an implementing PR) and the plan the `Source doc:` line.
 

--- a/skills/om-auto-implement-spec/references/engine-selection.md
+++ b/skills/om-auto-implement-spec/references/engine-selection.md
@@ -1,7 +1,7 @@
 # Choosing the implementation engine — plain vs loop, create vs continue
 
 How `om-auto-implement-spec` step 2 picks the engine. Two independent axes:
-**create vs continue** is decided by whether a spec PR already exists (continuation, never a second PR); **plain vs loop** is decided by the deterministic rule below — the same rule applies on both sides, so a qualifying spec gets the loop engine whether it starts fresh (`om-auto-create-pr-loop`) or continues a spec PR (`om-auto-continue-pr-loop`). This is also the path an issue takes through `om-auto-fix-issue`'s feature route, so the rule (and the `--loop` pass-through) applies there automatically.
+**create vs continue** is decided by whether a spec PR already exists (continuation, never a second PR); **plain vs loop** is decided by the deterministic rule below — the same rule applies on both sides, so a qualifying spec gets the loop engine whether it starts fresh (`om-auto-create-pr-loop`) or continues a spec PR (`om-auto-continue-pr-loop`). This is also the path an issue takes through `om-auto-fix-issue`'s feature route, so the rule applies there automatically (that route never passes `--loop` — only the >20-Step rule can select the loop for an issue-driven run).
 
 ## Why continuation, not a new create-pr run
 
@@ -15,7 +15,7 @@ The **plain engine** (`om-auto-continue-pr` when a spec PR exists, `om-auto-crea
 
 Select the **loop engine** (`om-auto-continue-pr-loop` when a spec PR exists, `om-auto-create-pr-loop` when not) only when at least one holds:
 
-1. **`--loop` was passed** to `om-auto-implement-spec` (or passed through from a routing skill such as `om-auto-fix-issue`) — the caller explicitly bought the loop's resumability and checkpoint discipline.
+1. **`--loop` was passed** to `om-auto-implement-spec` directly by the user — the caller explicitly bought the loop's resumability and checkpoint discipline. Routing skills never add it on their own.
 2. **The plan exceeds 20 Steps.** Count the Steps (not Phases) in the spec's Implementation Plan — the same items that become the plan's checklist/Tasks rows. More than 20 → loop.
 
 Nothing else selects the loop: not UI work (the plain engines post screenshots via `om-auto-qa-pr` / **attach-image-evidence**), not "might not finish in one pass" (`om-auto-continue-pr` resumes a plain run fine), not subjective "feels large". If the count is ambiguous (the spec lacks a step breakdown), draft the plan first, count its Steps, then decide.

--- a/skills/om-auto-implement-spec/references/engine-selection.md
+++ b/skills/om-auto-implement-spec/references/engine-selection.md
@@ -1,7 +1,7 @@
 # Choosing the implementation engine — plain vs loop, create vs continue
 
 How `om-auto-implement-spec` step 2 picks the engine. Two independent axes:
-**create vs continue** is decided by whether a spec PR already exists (continuation, never a second PR); **plain vs loop** is decided by spec size — the same size criteria apply on both sides, so a long spec gets the loop engine whether it starts fresh (`om-auto-create-pr-loop`) or continues a spec PR (`om-auto-continue-pr-loop`). This is also the path an issue takes through `om-auto-fix-issue`'s feature route, so a long-spec feature issue lands on the loop engine automatically.
+**create vs continue** is decided by whether a spec PR already exists (continuation, never a second PR); **plain vs loop** is decided by the deterministic rule below — the same rule applies on both sides, so a qualifying spec gets the loop engine whether it starts fresh (`om-auto-create-pr-loop`) or continues a spec PR (`om-auto-continue-pr-loop`). This is also the path an issue takes through `om-auto-fix-issue`'s feature route, so the rule (and the `--loop` pass-through) applies there automatically.
 
 ## Why continuation, not a new create-pr run
 
@@ -9,15 +9,19 @@ How `om-auto-implement-spec` step 2 picks the engine. Two independent axes:
 
 (The commit/push/label mechanics inside those skills follow the shared contract in `references/pr-finalize.md`: prefer `om-open-pr` when installed, inline otherwise, and never open a duplicate PR.)
 
-## The choice
+## The choice: plain unless the loop is earned
 
-Read the spec's **Implementation Plan** (Phases → Steps) and pick:
+The **plain engine** (`om-auto-continue-pr` when a spec PR exists, `om-auto-create-pr` when not) is the default — always. The loop engine's run-folder ceremony (PLAN/HANDOFF/NOTIFY, per-step commits, checkpoints) costs several times the tokens of a plain run, so it must be earned, never assumed.
 
-- **Plain engine** (`om-auto-continue-pr` when a spec PR exists, `om-auto-create-pr` when not) — the default. Use it for an ordinary spec: a handful of phases, a bounded number of steps, no need for mid-run checkpoints. Write the standard Progress-checklist plan (the format it parses) so it resumes from the first unchecked step and drives to `complete`.
-- **Loop engine** (`om-auto-continue-pr-loop` when a spec PR exists, `om-auto-create-pr-loop` when not) — for a **large, many-step** spec where resumability and strict step tracking matter: many phases/steps (roughly >8–10), UI work needing screenshots, or a plan that will not finish in one pass. It uses the **run-folder** format (`PLAN.md` Tasks table + `HANDOFF.md`/`NOTIFY.md`) that `om-auto-create-pr-loop` writes and checkpoints every ~5 steps.
+Select the **loop engine** (`om-auto-continue-pr-loop` when a spec PR exists, `om-auto-create-pr-loop` when not) only when at least one holds:
+
+1. **`--loop` was passed** to `om-auto-implement-spec` (or passed through from a routing skill such as `om-auto-fix-issue`) — the caller explicitly bought the loop's resumability and checkpoint discipline.
+2. **The plan exceeds 20 Steps.** Count the Steps (not Phases) in the spec's Implementation Plan — the same items that become the plan's checklist/Tasks rows. More than 20 → loop.
+
+Nothing else selects the loop: not UI work (the plain engines post screenshots via `om-auto-qa-pr` / **attach-image-evidence**), not "might not finish in one pass" (`om-auto-continue-pr` resumes a plain run fine), not subjective "feels large". If the count is ambiguous (the spec lacks a step breakdown), draft the plan first, count its Steps, then decide.
+
+State the decision in one line in the run report and PR summary comment: `Engine: <name> (steps: <N>, --loop: <yes|no>)`.
 
 ## Consequence for the plan format
 
-Decide the engine **before** committing the plan, because the two engines consume different plan formats: plain continue → the standard Progress-tracked execution plan (per `om-auto-create-pr` step 3); continue-loop → the run-folder in `om-auto-create-pr-loop`'s format, derived from the spec's phases and steps.
-
-When in doubt, prefer the plain `om-auto-continue-pr` engine — the loop variant is justified by scale, not used by default.
+Decide the engine **before** committing the plan, because the two engines consume different plan formats: plain → the standard Progress-tracked execution plan (per `om-auto-create-pr` step 3); loop → the run-folder in `om-auto-create-pr-loop`'s format (`PLAN.md` Tasks table + `HANDOFF.md`/`NOTIFY.md`), derived from the spec's phases and steps.

--- a/skills/om-auto-implement-spec/references/engine-selection.md
+++ b/skills/om-auto-implement-spec/references/engine-selection.md
@@ -1,7 +1,7 @@
 # Choosing the implementation engine — plain vs loop, create vs continue
 
 How `om-auto-implement-spec` step 2 picks the engine. Two independent axes:
-**create vs continue** is decided by whether a spec PR already exists (continuation, never a second PR); **plain vs loop** is decided by the deterministic rule below — the same rule applies on both sides, so a qualifying spec gets the loop engine whether it starts fresh (`om-auto-create-pr-loop`) or continues a spec PR (`om-auto-continue-pr-loop`). This is also the path an issue takes through `om-auto-fix-issue`'s feature route, so the rule applies there automatically (that route never passes `--loop` — only the >20-Step rule can select the loop for an issue-driven run).
+**create vs continue** is decided by whether a spec PR already exists (continuation, never a second PR); **plain vs loop** is decided by the deterministic rule below — the same rule applies on both sides, so a qualifying spec gets the loop engine whether it starts fresh (`om-auto-create-pr-loop`) or continues a spec PR (`om-auto-continue-pr-loop`). This is also the path an issue takes through `om-auto-fix-issue`'s feature route, so the rule applies there automatically (that route forwards `--loop` only when the user passed it to `om-auto-fix-issue`; it never adds it on its own).
 
 ## Why continuation, not a new create-pr run
 
@@ -15,7 +15,7 @@ The **plain engine** (`om-auto-continue-pr` when a spec PR exists, `om-auto-crea
 
 Select the **loop engine** (`om-auto-continue-pr-loop` when a spec PR exists, `om-auto-create-pr-loop` when not) only when at least one holds:
 
-1. **`--loop` was passed** to `om-auto-implement-spec` directly by the user — the caller explicitly bought the loop's resumability and checkpoint discipline. Routing skills never add it on their own.
+1. **`--loop` was passed** — by the user directly, or forwarded verbatim by a routing skill (e.g. `om-auto-fix-issue`) from the user's own invocation. The user explicitly bought the loop's resumability and checkpoint discipline; routing skills never add the flag on their own.
 2. **The plan exceeds 20 Steps.** Count the Steps (not Phases) in the spec's Implementation Plan — the same items that become the plan's checklist/Tasks rows. More than 20 → loop.
 
 Nothing else selects the loop: not UI work (the plain engines post screenshots via `om-auto-qa-pr` / **attach-image-evidence**), not "might not finish in one pass" (`om-auto-continue-pr` resumes a plain run fine), not subjective "feels large". If the count is ambiguous (the spec lacks a step breakdown), draft the plan first, count its Steps, then decide.


### PR DESCRIPTION
## 🎯 Goal

`om-auto-implement-spec` was too eager to pick the loop engines (`om-auto-create-pr-loop` / `om-auto-continue-pr-loop`) — the old criteria ("roughly >8–10 phases/steps, UI work, unlikely to finish in one pass") were fuzzy and expensive to satisfy: the loop's run-folder ceremony (PLAN/HANDOFF/NOTIFY, per-step commits, checkpoints) costs several times the tokens of a plain run. Make the plain engines (`om-auto-create-pr` / `om-auto-continue-pr`) the default, and gate the loop behind a deterministic rule.

Tracking plan: .ai/runs/2026-07-22-engine-selection-default-plain.md
Status: complete

## What Changed

- **`references/engine-selection.md` (om-auto-implement-spec)** — the plain engine is now the default, always. The loop engine is selected only when at least one holds: (1) the new **`--loop`** flag was passed — by the user directly or forwarded verbatim from the user's own invocation of a routing skill (routing skills never add it themselves), or (2) the spec's Implementation Plan has **more than 20 Steps** (count Steps, not Phases). Explicitly excluded triggers: UI work (plain engines post screenshots via `om-auto-qa-pr`), "might not finish in one pass" (`om-auto-continue-pr` resumes plain runs), and subjective size. The engine decision is reported as `Engine: <name> (steps: <N>, --loop: <yes|no>)`.
- **`om-auto-implement-spec/SKILL.md`** — new `--loop` argument; step 2's two engine branches (spec-PR continuation and fresh create) both rewritten to "plain by default, loop only on `--loop` or >20 Steps"; Chaining note aligned.
- **`om-auto-fix-issue`** — the feature route delegates to `om-auto-implement-spec` and forwards `--loop` **only when the user passed it to `om-auto-fix-issue` directly** (new pass-through argument); the route never adds the flag on its own. Without it, issue-driven runs reach the loop engine solely via the >20-Step rule.

No other skill states loop-selection criteria (verified by repo-wide grep); the engine skills themselves are unchanged.

## Tests

Docs/prose skills — no unit tests. Validation gate `bash scripts/lint.sh` (frontmatter, description/body budgets, product-agnostic, tracker abstraction): **Lint OK**.

## 💥 Breaking Changes

None at the contract level — no tracker-descriptor or config changes (hence no UPGRADE_NOTES entry). Behavioral shift by design: specs that previously landed on the loop engine via the fuzzy ">8–10" heuristic now run on the plain engine unless they exceed 20 Steps or the caller passes `--loop`.
