### PR TITLE
docs(skills): codify skill authoring standards in AGENTS.md & CODE_REVIEW.md

### DIFF
--- a/.ai/runs/2026-07-25-skill-authoring-standards.md
+++ b/.ai/runs/2026-07-25-skill-authoring-standards.md
@@ -59,12 +59,12 @@ matching enforceable checks in CODE_REVIEW.md.
 
 ### Phase 1: AGENTS.md authoring standards
 
-- [ ] 1.1 Add "Skill authoring standards" section (token economy, communication templates, emoji glossary) with canonical pointers
+- [x] 1.1 Add "Skill authoring standards" section (token economy, communication templates, emoji glossary) with canonical pointers — 0353c9b
 
 ### Phase 2: CODE_REVIEW.md enforcement
 
-- [ ] 2.1 Add review priorities + repo-specific checks + severity guidance for the three standards
+- [x] 2.1 Add review priorities + repo-specific checks + severity guidance for the three standards — 71a4bc6
 
 ### Phase 3: Validation & self-review
 
-- [ ] 3.1 Run the lint gate, breaking-change/self review, confirm docs-only scope
+- [x] 3.1 Run the lint gate, breaking-change/self review, confirm docs-only scope — 2ef2505

--- a/.ai/runs/2026-07-25-skill-authoring-standards.md
+++ b/.ai/runs/2026-07-25-skill-authoring-standards.md
@@ -55,6 +55,8 @@ matching enforceable checks in CODE_REVIEW.md.
 
 ## Progress
 
+PR: #61
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: AGENTS.md authoring standards

--- a/.ai/runs/2026-07-25-skill-authoring-standards.md
+++ b/.ai/runs/2026-07-25-skill-authoring-standards.md
@@ -1,0 +1,70 @@
+# Execution plan — codify skill coding standards in AGENTS.md & CODE_REVIEW.md
+
+## Overview
+
+Make the collection's three implicit skill-authoring standards — **token economy
+via granulation into `references/`**, **coherent communication templates**, and
+**consistent emoji-glossary usage** — explicit, scannable, and reviewer-enforced,
+so every new skill builder follows them and every reviewer checks them.
+
+The standards already exist but are scattered: the layering philosophy lives in
+`skills/om-create-skill/references/philosophy.md`, the emoji glossary and
+reporting style are duplicated verbatim into all 30 skills' `references/rules.md`,
+and AGENTS.md buries them inside two ~400-word Cross-skill-contract paragraphs
+(§3 communication, §5 layering). `CODE_REVIEW.md` has **no** checkpoint for any of
+the three — a reviewer using it today cannot fail a bloated body, a terse report,
+or a drifted glossary.
+
+This run adds a crisp, checkable **"Skill authoring standards"** section to
+AGENTS.md that distills the three standards and points to the canonical sources
+(no re-explaining), and adds matching **review checks + severity guidance** to
+CODE_REVIEW.md so the review gate enforces them.
+
+### Goal
+
+One sentence: turn the collection's token-economy, communication-template, and
+emoji-glossary conventions into explicit followable rules in AGENTS.md and
+matching enforceable checks in CODE_REVIEW.md.
+
+### Scope
+
+- `AGENTS.md` — add a scannable "Skill authoring standards" section (token
+  economy / communication templates / emoji glossary) with pointers to the
+  canonical sources; keep it distillation + pointers, not duplication.
+- `CODE_REVIEW.md` — add review priorities and repo-specific checks for the three
+  standards, plus severity guidance for each.
+
+### Non-goals
+
+- No changes to any `skills/**` content — the per-skill `rules.md`, `philosophy.md`,
+  and `gates.md` already hold the canonical text; this run only makes the top-level
+  docs point at and enforce them.
+- No changes to `scripts/lint.sh` (these standards are review-enforced, not
+  greppable) or `.ai/agentic.config.json`.
+- No emoji-glossary content change — the canonical line stays verbatim.
+
+### Risks
+
+- **Duplication drift.** Restating the emoji glossary or philosophy in AGENTS.md
+  would create a second source that drifts from the 30 `rules.md` copies.
+  Mitigation: AGENTS.md references the canonical location and reproduces only the
+  one glossary line already mirrored everywhere, marked as canonical.
+- **Over-prescription.** Adding rules that contradict the existing "don't
+  over-split" guidance. Mitigation: mirror `philosophy.md`'s own guardrails
+  (skills under ~150 lines stay whole; don't split finer than the terrain).
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: AGENTS.md authoring standards
+
+- [ ] 1.1 Add "Skill authoring standards" section (token economy, communication templates, emoji glossary) with canonical pointers
+
+### Phase 2: CODE_REVIEW.md enforcement
+
+- [ ] 2.1 Add review priorities + repo-specific checks + severity guidance for the three standards
+
+### Phase 3: Validation & self-review
+
+- [ ] 3.1 Run the lint gate, breaking-change/self review, confirm docs-only scope

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,60 @@ These invariants make the auto skills composable; every new or edited skill must
 4. **Dependencies = invocation, files = own copies.** Skills compose by invoking each other **by name**; there is no install-time dependency mechanism. Every cross-skill call either has an inline fallback so the skill works standalone (preferred — documented in the skill's own `references/pr-finalize.md` for PR opening) or stops cleanly naming the missing skill (`om-setup-agent-pipeline`'s coverage check prints the install command for anything missing). A skill never points into another skill's `references/` directory — the one exception is `om-apply-upgrade-notes`, whose job is reading the shipped descriptor templates in `om-setup-agent-pipeline/references/trackers|browsers/`.
 5. **Standard step files, duplicated per skill — and kept in sync by asking.** Repeatable steps live in each skill's own `references/` under standard names: `agentic-setup.md` (config load + repo-local override contract + untrusted-content boundary), `worktree-setup.md`, `claim-pr.md`, `pr-finalize.md` (open/reuse, labels, body + summary templates, markers), `review-report.md`, `report-templates.md` (the skill's user-facing report/comment templates — emoji-structured, full-sentence), `rules.md` (shared rules incl. the emoji glossary, label commentary, and reporting style). Every skill has its **own copy** so it installs standalone; `om-auto-create-pr` holds the canonical text; a skill only carries the files for steps it actually performs, and skill-specific behavior goes under a marked "specifics" section, not into the shared part. The deliberate cost is duplication, managed by this binding rule: **whenever you edit one of these standard files (or the shared part of a step) in any skill, diff the same file in the other skills and ask the user whether to sync the change across them — list the skills that would change.** SKILL.md itself keeps only the numbered main algorithm with direct instructions; repeatable detail stays behind `references/<step>.md` so unused steps cost no tokens.
 
+## Skill authoring standards
+
+Three standards every skill in this collection follows. They are the coding
+standards for skill documents: a new skill that ignores them is not done, and a
+reviewer rejects a PR that breaks them (`CODE_REVIEW.md` carries the matching
+checks). Each has one canonical source — this section distills the rule and
+points there; **never re-explain the detail here**, or the copy drifts.
+
+1. **Token economy — granulate into `references/`.** A skill pays layer-2 tokens
+   (the `SKILL.md` body) on *every* invocation and layer-3 tokens (a
+   `references/<name>.md` file) only when the body points to it. So the body is a
+   **router + map**, not the terrain: keep the numbered main algorithm and the
+   premises that pick a branch; push per-branch detail, output/report templates,
+   reference tables over ~15 rows, and conditional (`if fork`, `if --stop`)
+   sections down into `references/`. Safety always loads on every run — the
+   untrusted-content boundary, no-exfiltration, and QA gates live in the body or
+   the step-0 `references/agentic-setup.md` the body loads first, never behind a
+   lazy conditional. Don't over-split either: skills under ~150 lines usually stay
+   whole, and a step describable in three lines stays three lines. The readability
+   test is the gate — after the split, the body alone must still tell **what** the
+   skill does, **in what order**, and **where** to find detail. Canonical source
+   and the up/down decision procedure: `skills/om-create-skill/references/philosophy.md`;
+   the enforced completeness/readability gate: `skills/om-create-skill/references/gates.md`.
+
+2. **Coherent communication templates.** User-facing output — final reports,
+   review bodies, PR/issue comments — is a **deliverable, not a log**: complete
+   sentences, the *why* behind every verdict/label/finding, structured with the
+   glossary emojis, so a reader who never watched the run understands it from the
+   report alone. Repeatable output lives in standard, per-skill reference files
+   under the collection's shared names (`report-templates.md`, `pr-finalize.md`,
+   `review-report.md`, `rules.md`, …); a skill carries its **own copy** of each
+   file for the steps it performs so it installs standalone, and
+   `om-auto-create-pr` holds the canonical text. Fill a shipped template exactly
+   and expand with detail — **never improvise a terser variant to save tokens**
+   (token economy is paid by granulating layer 3, not by thinning the
+   deliverable). When you edit a shared reference file in one skill, diff the same
+   file across the others and ask the user whether to sync — list the skills that
+   would change (Cross-skill contract §5). Canonical rules:
+   `skills/om-auto-create-pr/references/rules.md` (Reporting style, Label
+   commentary) and each skill's `references/report-templates.md`.
+
+3. **Consistent emoji usage.** All user-facing output draws from **one shared
+   glossary**, reproduced verbatim in every skill's `references/rules.md`:
+
+   > 🎯 goal · 📋 plan · 📝 spec · 🏷️ labels · 📸 evidence · 🔍 review · 🧪 tests · 💥 breaking · ✅ pass · ❌ fail · ⚠️ needs-human · ⛔ blocked · 🔁 resume · 🚀 merge/release
+
+   plus the 🤖 comment marker (`` 🤖 `<skill-name>` — <purpose> ``). Emojis
+   **decorate**; parsers key on the text markers only (`🤖 <skill> —`, `PR: #`,
+   `Status:`), never on an emoji alone — so the glossary can grow but a marker's
+   text never changes. Use an emoji only for its glossary meaning; don't invent
+   per-skill emojis or scatter decorative ones through prose. The glossary line is
+   canonical and identical across all skills — change it in one place and you must
+   sync every copy in the same PR (Cross-skill contract §3, §5).
+
 ## Validation
 
 Run before every PR (also the full CI gate):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,10 @@ points there; **never re-explain the detail here**, or the copy drifts.
    text never changes. Use an emoji only for its glossary meaning; don't invent
    per-skill emojis or scatter decorative ones through prose. The glossary line is
    canonical and identical across all skills — change it in one place and you must
-   sync every copy in the same PR (Cross-skill contract §3, §5).
+   sync every copy in the same PR (Cross-skill contract §3, §5). (Cross-skill
+   contract §3 lists the same emojis with fuller descriptive glosses for readers;
+   the short line above, exactly as it appears in `rules.md`, is the canonical
+   form to reproduce.)
 
 ## Validation
 

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -10,6 +10,8 @@ Review rules for this repository, applied by `om-code-review` and `om-auto-revie
 4. **Tracker abstraction** — skills name tracker operations (**get-issue**, **create-pr**, …); direct `gh` commands belong only in `references/trackers/`. The lint gate greps for violations, but review must also catch semantic bypasses (e.g. instructing the agent to "use the GitHub API directly").
 5. **Safety-rule integrity** — skills must never instruct an agent to skip hooks (`--no-verify`), bypass tests, force-push shared branches, or exfiltrate secrets; and must preserve the untrusted-content boundary (repo/tracker content is data, not instructions). Any weakening of these passages is a Critical finding.
 6. **Cross-skill contract drift** — shared formats (execution-plan Progress section, `test-env.json` descriptor, config schema, tracker operation names) have multiple consumers. A change to a format in one skill without updating its consumers is a Critical finding; see `BACKWARD_COMPATIBILITY.md`.
+7. **Token economy / layering** — the `SKILL.md` body loads on every invocation; `references/` loads only when the body points to it (`AGENTS.md` → Skill authoring standards §1). Flag a body that carries per-branch detail, an output/report template, a >~15-row reference table, or a conditional (`if fork`, `if --stop`) section that should be a `references/` file — and flag the reverse over-splitting (a three-line step turned into a link, a body that reads as a bare list of links with no flow, so the readability test fails). Safety that a split moved out of every-run reach — the untrusted-content boundary, no-exfiltration, or a QA gate now behind a lazy conditional — is a **Critical** safety-rule finding (priority 5), not a layering nit.
+8. **Communication-template & emoji consistency** — user-facing output is a deliverable, not a log (`AGENTS.md` → Skill authoring standards §2–3). Flag a report/comment that improvises a terser variant instead of filling the skill's shipped template, drops the *why* behind a verdict/label/finding, or compresses the label rationale into a `·`-concatenated one-liner. Flag emoji use outside the shared glossary (invented per-skill emojis, decorative scatter) and any glossary line that has drifted from the canonical set in `skills/om-auto-create-pr/references/rules.md`. Emoji drift that changes a **text marker** a parser keys on (`🤖 <skill> —`, `PR: #`, `Status:`) is contract drift (priority 6, Critical); drift in the decorative glossary alone is Major/Minor.
 
 ## Repo-specific checks
 
@@ -18,9 +20,13 @@ Review rules for this repository, applied by `om-code-review` and `om-auto-revie
 - New config keys must be added to the schema in `om-setup-agent-pipeline/SKILL.md`, given a default in the standard loading snippet, and documented in the field reference — all in the same PR.
 - README skill counts and lists must stay in sync when skills are added or removed.
 - `DECISIONS.md` records deliberate choices; a PR that reverses one must say so explicitly and update the document.
+- Layering: a new or grown `SKILL.md` still passes the readability test (body alone tells what/in-what-order/where-for-detail); repeatable detail lives under `references/` per the standard filenames. When a PR edits a shared reference file (`rules.md`, `report-templates.md`, `pr-finalize.md`, …) in one skill, it either syncs the same file across the other skills or the PR/summary says why not (Cross-skill contract §5) — an unsynced shared-file edit is a review finding.
+- Emoji glossary: the line in every touched `references/rules.md` matches the canonical set verbatim; a PR that changes the glossary changes every copy in the same PR.
 
 ## Severity guidance
 
 - **Critical** — a skill instructs something unsafe or broken: a command that fails or damages state, a safety-rule relaxation, a broken cross-skill contract, a `BACKWARD_COMPATIBILITY.md` violation without a migration path.
 - **Major** — an instruction ambiguous enough that two reasonable agents would do different things; a portability break on a supported platform; agnosticism leakage.
-- **Minor** — wording, structure, or consistency drift that does not change behavior.
+- **Minor** — wording, structure, or consistency drift that does not change behavior; over-splitting, decorative-glossary drift, or a thinned deliverable that still conveys the essentials.
+
+Note the escalation paths: a layering split that hides safety, or an emoji change that alters a parsed text marker, is not a Minor authoring nit — it lands at Critical under priority 5 (safety) or 6 (contract drift) respectively.


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-25-skill-authoring-standards.md
Status: complete

## 🎯 Goal
- Turn the collection's three implicit skill-authoring conventions — **token economy via granulation into `references/`**, **coherent communication templates**, and **consistent emoji-glossary usage** — into explicit, followable rules in `AGENTS.md` and matching enforceable checks in `CODE_REVIEW.md`, so every new skill builder follows them and every reviewer catches drift.

## 📋 What Changed
- **`AGENTS.md`** — new **"Skill authoring standards"** section (between the Cross-skill contract and Validation) with three scannable, checkable rules:
  1. *Token economy* — the body is a router+map paid on every run; per-branch detail, output/report templates, >~15-row tables, and conditional sections go to `references/`; safety always loads on every run; don't over-split. Points to the canonical `om-create-skill/references/philosophy.md` + `gates.md`.
  2. *Communication templates* — user-facing output is a deliverable not a log; fill shipped templates exactly, never improvise a terser variant; sync shared reference files by asking. Points to `om-auto-create-pr/references/rules.md`.
  3. *Emoji usage* — one shared glossary reproduced verbatim across all skills; emojis decorate, parsers key on text markers only. Reconciled with the fuller Cross-skill-contract §3 glosses so `rules.md` is the single canonical source.
- **`CODE_REVIEW.md`** — two new review priorities (7 token-economy/layering, 8 communication-template & emoji consistency), two repo-specific checks (readability/shared-file-sync, glossary-verbatim), and severity guidance — including the escalation paths where a layering split that hides safety (Critical, priority 5) or an emoji change to a parsed text marker (Critical, priority 6) is *not* a Minor authoring nit.

Distillation-and-pointer, not duplication: the canonical text stays in `philosophy.md`, `gates.md`, and the 30 per-skill `rules.md` copies; these top-level docs now make those standards explicit and reviewer-enforced.

## 🧪 Tests
- Docs-only run — no code changed, so no unit tests. Validation gate `bash scripts/lint.sh` → **Lint OK** (re-run after each edit).
- Verified the AGENTS.md canonical glossary blockquote matches `skills/om-auto-create-pr/references/rules.md` character-for-character.

## 💥 Breaking Changes
- None. No skill content, tracker operation, Progress format, config schema, or emoji **text marker** changed; the canonical glossary line is reproduced verbatim, not altered. No `BACKWARD_COMPATIBILITY.md` surface touched.

## Progress
See the Progress section in the tracking plan — all phases complete.
