### PR TITLE
docs(changelog): add 1.1.0 release entry

### DIFF
--- a/.ai/runs/2026-08-13-changelog-1.1.0.md
+++ b/.ai/runs/2026-08-13-changelog-1.1.0.md
@@ -44,9 +44,9 @@ Publish a draft `CHANGELOG.md` entry for release 1.1.0 covering the merged pull 
 
 ### Phase 1: Draft the release entry
 
-- [ ] 1.1 Resolve the release boundary and enumerate eligible merged pull requests
-- [ ] 1.2 Apply category, issue-reference, contributor, bot-exclusion, and supersede-credit rules
-- [ ] 1.3 Add the 1.1.0 block to `CHANGELOG.md` in the established format
+- [x] 1.1 Resolve the release boundary and enumerate eligible merged pull requests — 5be3cb9
+- [x] 1.2 Apply category, issue-reference, contributor, bot-exclusion, and supersede-credit rules — 5be3cb9
+- [x] 1.3 Add the 1.1.0 block to `CHANGELOG.md` in the established format — 5be3cb9
 
 ### Phase 2: Verify and publish
 

--- a/.ai/runs/2026-08-13-changelog-1.1.0.md
+++ b/.ai/runs/2026-08-13-changelog-1.1.0.md
@@ -40,6 +40,8 @@ Publish a draft `CHANGELOG.md` entry for release 1.1.0 covering the merged pull 
 
 ## Progress
 
+PR: #84
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Draft the release entry
@@ -52,4 +54,4 @@ Publish a draft `CHANGELOG.md` entry for release 1.1.0 covering the merged pull 
 
 - [x] 2.1 Confirm the release entry is complete and only `CHANGELOG.md` contains release-content changes — 5be3cb9
 - [x] 2.2 Run the docs-only validation gate and self-review the final diff — 4b7d9f8
-- [ ] 2.3 Open and label the pull request, then complete the automated review pass
+- [x] 2.3 Open and label the pull request, then complete the automated review pass — a6ef67a

--- a/.ai/runs/2026-08-13-changelog-1.1.0.md
+++ b/.ai/runs/2026-08-13-changelog-1.1.0.md
@@ -50,6 +50,6 @@ Publish a draft `CHANGELOG.md` entry for release 1.1.0 covering the merged pull 
 
 ### Phase 2: Verify and publish
 
-- [ ] 2.1 Confirm the release entry is complete and only `CHANGELOG.md` contains release-content changes
-- [ ] 2.2 Run the docs-only validation gate and self-review the final diff
+- [x] 2.1 Confirm the release entry is complete and only `CHANGELOG.md` contains release-content changes — 5be3cb9
+- [x] 2.2 Run the docs-only validation gate and self-review the final diff — 4b7d9f8
 - [ ] 2.3 Open and label the pull request, then complete the automated review pass

--- a/.ai/runs/2026-08-13-changelog-1.1.0.md
+++ b/.ai/runs/2026-08-13-changelog-1.1.0.md
@@ -1,0 +1,55 @@
+# Update changelog for 1.1.0
+
+## Overview
+
+### Goal
+
+Publish a draft `CHANGELOG.md` entry for release 1.1.0 covering the merged pull requests since 1.0.0.
+
+### Scope
+
+- Resolve the release window from the existing changelog and the `v1.0.0` tag.
+- Categorize eligible pull requests merged into `main`, preserve issue links, and credit human contributors.
+- Prepend the 1.1.0 release entry while matching the repository's existing changelog format.
+- Publish the result as a documentation-only, low-risk pull request.
+
+### Non-goals
+
+- Do not write the Highlights narrative; retain the human-review TODO marker.
+- Do not bump the package manifest or create a release tag.
+- Do not change product code, skill instructions, or other documentation.
+
+## Implementation Plan
+
+### Phase 1: Draft the release entry
+
+1. Resolve the release boundary and enumerate eligible merged pull requests.
+2. Apply category, issue-reference, contributor, bot-exclusion, and supersede-credit rules.
+3. Add the 1.1.0 block to `CHANGELOG.md` in the established format.
+
+### Phase 2: Verify and publish
+
+1. Confirm the release entry is complete and only `CHANGELOG.md` contains release-content changes.
+2. Run the docs-only validation gate and self-review the final diff.
+3. Open and label the pull request, then complete the automated review pass.
+
+## Risks
+
+- The release boundary is date-based and inclusive. Pull requests already recorded in 1.0.0 and the prior changelog-only PR are excluded to prevent duplicate/self-referential entries.
+- The Highlights section remains intentionally blank for a maintainer to complete before release.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Draft the release entry
+
+- [ ] 1.1 Resolve the release boundary and enumerate eligible merged pull requests
+- [ ] 1.2 Apply category, issue-reference, contributor, bot-exclusion, and supersede-credit rules
+- [ ] 1.3 Add the 1.1.0 block to `CHANGELOG.md` in the established format
+
+### Phase 2: Verify and publish
+
+- [ ] 2.1 Confirm the release entry is complete and only `CHANGELOG.md` contains release-content changes
+- [ ] 2.2 Run the docs-only validation gate and self-review the final diff
+- [ ] 2.3 Open and label the pull request, then complete the automated review pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,52 @@
+# 1.1.0 (2026-08-13)
+
+## Highlights
+<!-- TODO: Highlights — auto-update-changelog leaves this blank for the human author to fill in. -->
+
+## ✨ Features
+- ✨ Reframe doc-originated spec PRs into feature PRs. (#46) *(@pkarw)*
+- ✨ Default to plain engine, gate loop behind >20 steps or `--loop`. (#47) *(@pkarw)*
+- ✨ Templated reporting, autofix opt-in, atomic spec PRs, idempotent label rationale. (#49) *(@pkarw)*
+- ✨ Self-route plain vs loop — engine selection moves into the engine, threshold configurable. (#54) *(@matgren)*
+- ✨ Plan-time executor dispatch — `Exec` column in the Tasks table + abstract model tiers. (#55) *(@matgren)*
+- ✨ `om-brainstorm` — the divergent conversation that routes into the pipeline. (#58) *(@matgren)*
+- ✨ Address reviewer comments already posted on the PR. (#66) *(@pkarw)*
+- ✨ `om-ux-shape`, `om-ux-setup`, `om-ux-review-pr` — the UX judgment layer. (#57) *(@zielivia)*
+- ✨ Add `om-pr-autopilot` PR dispatcher skill. (#65) *(@wojciechszyjka)*
+- ✨ Adopt PRs that were never planned instead of giving up on them. (#69) *(@pkarw)*
+- ✨ `om-pipeline-retro`: classify finished runs and rank what second passes cost. (#68) *(@matgren)*
+- ✨ Test-env credentials become references — password values never enter the agent's context. (#81) *(@matgren)*
+
+## 🐛 Fixes
+- 🐛 Consolidate label rationale into one comment, strengthen PR body placeholders (fixes #44). (#45) *(@pkarw)*
+- 🐛 Deduplicate chained review passes. (#48) *(@pkarw)*
+- 🔧 Mutate GitHub labels, assignees, and bodies through REST. (#67) *(@pkarw)*
+- 🔧 Report before CI, label the watch phase with `ci-monitoring`, bound the wait. (#73) *(@pkarw)*
+- 🔧 Clear the Critical/High skills.sh audit findings without changing skill behavior. (#76) *(@matgren)*
+- 🐛 Make close-keyword matching configurable (fixes #75). (#79) *(@pkarw)*
+
+## 🛠️ Improvements
+- 🛠️ Simplify algorithms — remove redundant reads and a dead branch (behavior-preserving). (#51) *(@pkarw)*
+- 🛠️ Chore/simplify algorithms. (#53) *(@pkarw)*
+- 🛠️ Keep the pinned agent-browser at the latest stable release. (#78) *(@matgren)*
+
+## 📝 Specs & Documentation
+- 📝 Explain how to update installed skills. (#42) *(@pkarw)*
+- 📝 Codify skill authoring standards in AGENTS.md & CODE_REVIEW.md. (#61) *(@pkarw)*
+- 📝 Credit the author, not the merger. (#74) *(@patzick)*
+- 📝 Canonical Security boundaries section for every skill with a non-clean audit rating. (#77) *(@matgren)*
+- 📝 Split safe no-op review detection from comment budgeting. (#80) *(@wojciechszyjka)*
+
+## 👥 Contributors
+
+- @pkarw
+- @matgren
+- @zielivia
+- @wojciechszyjka
+- @patzick
+
+---
+
 # 1.0.0 (2026-07-21)
 
 ## Highlights


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-13-changelog-1.1.0.md
Status: complete

## 🎯 Goal

- Add a draft `CHANGELOG.md` entry for release 1.1.0 covering eligible pull requests merged since 1.0.0.

## What Changed

- Added the 1.1.0 release block for 26 merged PRs across Features, Fixes, Improvements, and Specs & Documentation.
- Preserved authoritative issue references, excluded bots, and credited five human contributors.
- Excluded stacked-branch merges, PRs already recorded in 1.0.0, and the prior changelog-only PR to avoid duplicate or non-release entries.
- Kept the Highlights TODO marker for the maintainer's release narrative.

## 🧪 Tests

- `bash scripts/lint.sh` — pass (`Lint OK`).
- Manual diff review confirmed the established changelog format and release-entry count.
- `om-auto-review-pr` found no blockers or major findings; GitHub rejected formal self-approval because the reviewer and PR author are the same account, so the PR remains in `review` for independent approval.

## 💥 Breaking Changes

- None. This is a documentation-only release-note update and changes no protected contract surface.

## 📋 Progress

See the Progress section in the tracking plan.
