### PR TITLE
docs(spec): define shell-neutral cross-platform compatibility plan

### DIFF
--- a/.ai/runs/2026-08-25-windows-compatibility-spec.md
+++ b/.ai/runs/2026-08-25-windows-compatibility-spec.md
@@ -53,6 +53,8 @@ Determine whether the collection needs changes to run on Windows, then publish a
 
 ## Progress
 
+PR: #87
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Compatibility audit
@@ -63,5 +65,5 @@ Determine whether the collection needs changes to run on Windows, then publish a
 ### Phase 2: Specification and verification
 
 - [x] 2.1 Author the implementation-ready Windows compatibility specification — 0b13530
-- [ ] 2.2 Complete fresh-context scope-cohesion review and incorporate findings
+- [x] 2.2 Complete fresh-context scope-cohesion review and incorporate findings — 8d2461b
 - [ ] 2.3 Pass validation and finalize the spec-only PR

--- a/.ai/runs/2026-08-25-windows-compatibility-spec.md
+++ b/.ai/runs/2026-08-25-windows-compatibility-spec.md
@@ -6,26 +6,26 @@ Branch: feat/windows-compatibility-spec
 
 ## Goal
 
-Determine whether the collection needs changes to run from native Windows shells, then publish an implementation-ready specification for closing the verified gaps without changing the skills in this PR.
+Determine whether the collection needs changes to run on Windows, then publish an implementation-ready shell-neutral specification that avoids maintaining separate operating-system branches.
 
 ## Scope
 
 - Audit the current skill instructions, duplicated standard references, tracker and browser descriptors, repository tooling, and validation configuration for native Windows/PowerShell assumptions.
 - Distinguish existing Windows support from remaining blockers so the proposal does not repeat the cross-platform test-environment work already merged in PR #18.
-- Define a backward-compatible platform execution contract, affected-file matrix, validation strategy, rollout phases, and testable implementation steps.
+- Define one backward-compatible structured-operation contract, affected-file matrix, validation strategy, rollout phases, and testable implementation steps.
 - Produce a spec-only design PR under `.ai/specs/`; no runtime skill or tooling behavior changes in this run.
 
 ## Resolved assumptions (autonomous defaults)
 
-- **Windows target:** native Windows agents using PowerShell plus Git for Windows. This is the smallest useful target that removes the current Bash dependency. Git Bash remains a supported POSIX route; WSL remains covered by the Linux/POSIX route.
-- **PowerShell baseline:** prefer PowerShell 7 (`pwsh`) for maintained cross-platform recipes, while documenting a narrow Windows PowerShell 5.1 fallback only where the repository already promises it. Avoid designing every operation around 5.1 limitations.
-- **Compatibility:** preserve existing config keys, tracker/browser operation names, execution-plan formats, and POSIX recipes. New platform metadata or command variants must be additive with fallbacks for older committed consumer configuration.
+- **Execution model:** use agent structured file capabilities and direct program/argument invocation. Do not maintain Bash and PowerShell control-flow variants or introduce a shell selector.
+- **Prerequisites:** Git is required for Git workflows and each tracker descriptor declares its client (`gh` for GitHub). Node is allowed for this source repository's existing tooling but is not required by installed skills; Python is not added.
+- **Compatibility:** preserve existing config keys, tracker/browser operation names, execution-plan formats, and legacy command/entrypoint fields. New structured process forms are additive and old forms fail cleanly when no compatible runner exists.
 - **Deliverable:** analysis and specification only. Implementation, broad standard-file synchronization, and Windows CI changes are deferred to the follow-up implementation PR.
 
 ## Non-goals
 
 - Implementing PowerShell variants or changing any `skills/**` instructions in this PR.
-- Requiring WSL or Git Bash as the native-Windows solution.
+- Requiring PowerShell, WSL, Git Bash, Node, or Python as an installed-skill orchestration runtime.
 - Adding non-GitHub tracker providers or changing tracker semantics.
 - Guaranteeing that arbitrary target repositories' own validation commands are portable; the pipeline will define how platform-specific commands are selected and reported.
 - Replacing platform-native project tooling when a repository already supplies a working command for the current shell.
@@ -47,8 +47,8 @@ Determine whether the collection needs changes to run from native Windows shells
 
 - **Broad duplicated surface:** the standard setup and worktree references are copied into multiple skills. A later implementation that updates only one copy will drift; the follow-up must enumerate and synchronize every affected copy under the repository's standard-file rule.
 - **Protected consumer state:** tracker descriptors and `.ai/agentic.config.json` are committed in downstream repositories. The design must remain usable with older copies and cannot silently require regeneration.
-- **False portability from agent translation:** prose that merely tells an agent to “translate Bash” can still fail on quoting, paths, JSON, background processes, and cleanup. The spec must identify where semantic recipes or executable tests are required.
-- **PowerShell version split:** Windows PowerShell 5.1 and PowerShell 7 differ in encoding and native argument behavior. The proposal must state the baseline and keep any fallback explicit.
+- **Executor capability variance:** some agents expose only shell command strings rather than direct argv/process capabilities. The specification must make direct invocation a preflight capability and stop before mutation when unavailable.
+- **Legacy repositories:** opaque validation strings and `.sh`/`.ps1` entrypoints remain in committed consumer state. The additive structured form must preserve readable legacy state without guessing or translating it.
 - **Scope inflation:** native Windows support spans authoring instructions and this repository's developer tooling. The spec must phase the work and separate pipeline-runtime blockers from lower-priority contributor conveniences.
 
 ## Progress

--- a/.ai/runs/2026-08-25-windows-compatibility-spec.md
+++ b/.ai/runs/2026-08-25-windows-compatibility-spec.md
@@ -1,0 +1,67 @@
+# Execution plan: specify native Windows compatibility for the skills collection
+
+Date: 2026-08-25
+Slug: windows-compatibility-spec
+Branch: feat/windows-compatibility-spec
+
+## Goal
+
+Determine whether the collection needs changes to run from native Windows shells, then publish an implementation-ready specification for closing the verified gaps without changing the skills in this PR.
+
+## Scope
+
+- Audit the current skill instructions, duplicated standard references, tracker and browser descriptors, repository tooling, and validation configuration for native Windows/PowerShell assumptions.
+- Distinguish existing Windows support from remaining blockers so the proposal does not repeat the cross-platform test-environment work already merged in PR #18.
+- Define a backward-compatible platform execution contract, affected-file matrix, validation strategy, rollout phases, and testable implementation steps.
+- Produce a spec-only design PR under `.ai/specs/`; no runtime skill or tooling behavior changes in this run.
+
+## Resolved assumptions (autonomous defaults)
+
+- **Windows target:** native Windows agents using PowerShell plus Git for Windows. This is the smallest useful target that removes the current Bash dependency. Git Bash remains a supported POSIX route; WSL remains covered by the Linux/POSIX route.
+- **PowerShell baseline:** prefer PowerShell 7 (`pwsh`) for maintained cross-platform recipes, while documenting a narrow Windows PowerShell 5.1 fallback only where the repository already promises it. Avoid designing every operation around 5.1 limitations.
+- **Compatibility:** preserve existing config keys, tracker/browser operation names, execution-plan formats, and POSIX recipes. New platform metadata or command variants must be additive with fallbacks for older committed consumer configuration.
+- **Deliverable:** analysis and specification only. Implementation, broad standard-file synchronization, and Windows CI changes are deferred to the follow-up implementation PR.
+
+## Non-goals
+
+- Implementing PowerShell variants or changing any `skills/**` instructions in this PR.
+- Requiring WSL or Git Bash as the native-Windows solution.
+- Adding non-GitHub tracker providers or changing tracker semantics.
+- Guaranteeing that arbitrary target repositories' own validation commands are portable; the pipeline will define how platform-specific commands are selected and reported.
+- Replacing platform-native project tooling when a repository already supplies a working command for the current shell.
+
+## Implementation Plan
+
+### Phase 1: Compatibility audit
+
+1. Inventory the current Windows-aware surfaces and the remaining native-Windows blockers across skills, standard references, descriptors, configuration, and repository tooling.
+2. Check protected contracts and authoritative platform guidance, then classify required changes by severity, compatibility risk, and ownership.
+
+### Phase 2: Specification and verification
+
+1. Author the Windows compatibility specification with resolved assumptions, proposed platform contract, affected-file matrix, failure modes, rollout phases, and testable implementation steps.
+2. Run the required fresh-context scope-cohesion review and incorporate actionable findings without expanding into implementation.
+3. Run the full documentation validation gate, complete the self-review and automated PR review, and finalize the spec-only PR for human review.
+
+## Risks
+
+- **Broad duplicated surface:** the standard setup and worktree references are copied into multiple skills. A later implementation that updates only one copy will drift; the follow-up must enumerate and synchronize every affected copy under the repository's standard-file rule.
+- **Protected consumer state:** tracker descriptors and `.ai/agentic.config.json` are committed in downstream repositories. The design must remain usable with older copies and cannot silently require regeneration.
+- **False portability from agent translation:** prose that merely tells an agent to “translate Bash” can still fail on quoting, paths, JSON, background processes, and cleanup. The spec must identify where semantic recipes or executable tests are required.
+- **PowerShell version split:** Windows PowerShell 5.1 and PowerShell 7 differ in encoding and native argument behavior. The proposal must state the baseline and keep any fallback explicit.
+- **Scope inflation:** native Windows support spans authoring instructions and this repository's developer tooling. The spec must phase the work and separate pipeline-runtime blockers from lower-priority contributor conveniences.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Compatibility audit
+
+- [ ] 1.1 Inventory current support and native-Windows blockers
+- [ ] 1.2 Classify required changes against contracts and authoritative guidance
+
+### Phase 2: Specification and verification
+
+- [ ] 2.1 Author the implementation-ready Windows compatibility specification
+- [ ] 2.2 Complete fresh-context scope-cohesion review and incorporate findings
+- [ ] 2.3 Pass validation and finalize the spec-only PR

--- a/.ai/runs/2026-08-25-windows-compatibility-spec.md
+++ b/.ai/runs/2026-08-25-windows-compatibility-spec.md
@@ -57,11 +57,11 @@ Determine whether the collection needs changes to run from native Windows shells
 
 ### Phase 1: Compatibility audit
 
-- [ ] 1.1 Inventory current support and native-Windows blockers
-- [ ] 1.2 Classify required changes against contracts and authoritative guidance
+- [x] 1.1 Inventory current support and native-Windows blockers — 0b13530
+- [x] 1.2 Classify required changes against contracts and authoritative guidance — 0b13530
 
 ### Phase 2: Specification and verification
 
-- [ ] 2.1 Author the implementation-ready Windows compatibility specification
+- [x] 2.1 Author the implementation-ready Windows compatibility specification — 0b13530
 - [ ] 2.2 Complete fresh-context scope-cohesion review and incorporate findings
 - [ ] 2.3 Pass validation and finalize the spec-only PR

--- a/.ai/runs/2026-08-25-windows-compatibility-spec.md
+++ b/.ai/runs/2026-08-25-windows-compatibility-spec.md
@@ -66,4 +66,4 @@ PR: #87
 
 - [x] 2.1 Author the implementation-ready Windows compatibility specification — 0b13530
 - [x] 2.2 Complete fresh-context scope-cohesion review and incorporate findings — 8d2461b
-- [ ] 2.3 Pass validation and finalize the spec-only PR
+- [x] 2.3 Pass validation and finalize the spec-only PR — 32f4711

--- a/.ai/specs/2026-08-25-native-windows-changelog-window.md
+++ b/.ai/specs/2026-08-25-native-windows-changelog-window.md
@@ -1,0 +1,27 @@
+# Shell-Neutral Changelog Window
+
+## TLDR
+
+Remove shell pipelines from changelog release-window reachability and temporary commit-set handling.
+
+## Dependency and scope
+
+Depends on config/setup and exclusively owns `skills/om-auto-update-changelog/SKILL.md` plus `references/release-window.md`.
+
+## Proposed solution
+
+Replace `/tmp`, pipelines, and command substitution with agent temp files, direct Git argument arrays, and structured result sets. Preserve ordering, merge-base/reachability rules, deduplication, and empty-window semantics.
+
+## Validation and plan
+
+1.1 Build graph fixtures for linear, merged, divergent, shallow, missing-tag, and empty windows.
+
+1.2 Implement one semantic recipe with explicit exit checks and guaranteed owned cleanup.
+
+1.3 Compare exact selected commit IDs/order on Ubuntu and Windows and assert no shell process; run repository lint.
+
+## Completion Criteria
+
+- Every graph fixture produces identical semantic windows on both OSes.
+- Temporary files are platform-native and removed on success/failure.
+- No changelog output contract changes.

--- a/.ai/specs/2026-08-25-native-windows-core-pr-workflows.md
+++ b/.ai/specs/2026-08-25-native-windows-core-pr-workflows.md
@@ -1,0 +1,23 @@
+# Shell-Neutral Author, Open, and Fix Workflows
+
+## TLDR
+
+Move the tightly coupled author/open/fix chain to structured operations without OS branches.
+
+## Dependencies and scope
+
+Depends on config/setup, worktree, and tracker specs. Owns non-standard instructions for `om-auto-create-pr`, `om-auto-fix-issue`, `om-auto-fix-pr`, `om-fix`, `om-open-pr`, and `om-verify-in-repo`.
+
+## Proposed solution
+
+Use structured files, direct argv, and named tracker operations while preserving verification, claim, isolation, validation, PR reuse/open, labels, handback, and chaining. Early draft is allowed only while Progress is incomplete; completed ordinary PRs are ready, while completed spec-only PRs remain draft.
+
+## Validation and plan
+
+1.1 Define per-route postconditions. 1.2 migrate author/open and test new/existing PR plus draft rules. 2.1 migrate verify/fix and test verified/unverified issues, claim conflict, failure, handback, cleanup. 2.2 execute all six routes separately on Ubuntu/Windows and assert exact argv/no shell.
+
+## Completion Criteria
+
+- All six routes pass route-specific success/failure fixtures on both OSes.
+- Protected claims, labels, readiness, chaining, handback, and cleanup remain compatible.
+- No platform branch or shell orchestration remains.

--- a/.ai/specs/2026-08-25-native-windows-execution-foundation.md
+++ b/.ai/specs/2026-08-25-native-windows-execution-foundation.md
@@ -1,0 +1,35 @@
+# Shell-Neutral Config and Setup Foundation
+
+## TLDR
+
+Define the shared operation/config contract and synchronize shell-neutral config loading across every setup copy.
+
+## Dependency and scope
+
+Depends on the cross-platform validation gate. Owns `.ai/agentic.config.json`, `AGENTS.md`, `DECISIONS.md`, `SDLC.md`, config sections of `BACKWARD_COMPATIBILITY.md`, the setup skill’s `SKILL.md`, `interview-questions.md`, `project-docs.md`, and `skill-coverage.md`, all 36 `agentic-setup.md` copies, and a config contract workflow.
+
+## Proposed solution
+
+Define `file`, direct `process`, `tracker`, and `decision` operations. Parse config directly as JSON. Add optional validated `validation.steps` and prefer it over legacy strings without translation or platform variants. Preflight required agent capabilities and configured executables before mutation.
+
+## Compatibility and failures
+
+Legacy commands remain usable with a compatible runner; otherwise stop with migration guidance. Invalid structured steps never fall back. Missing file/process/temp/status/cleanup capability fails preflight.
+
+## Synchronization gate
+
+Ask to synchronize the roadmap’s exact 36 setup owners before editing. Without authorization, stop. Update every shared copy in one PR, machine-check equality, and preserve specifics.
+
+## Validation and plan
+
+1.1 Record authorization and add capability/config fixtures for absent, structured, legacy, malformed, and missing-program states.
+
+1.2 Update config/process/compatibility documents and setup-skill authoring instructions together.
+
+1.3 Synchronize all 36 copies and add required Ubuntu/Windows config-contract CI.
+
+## Completion Criteria
+
+- One algorithm, no OS/shell selector, and no installed scripting-runtime requirement.
+- Config behavior is deterministic/backward compatible on Ubuntu/Windows.
+- All 36 copies are authorized, synchronized, and specifics-preserving.

--- a/.ai/specs/2026-08-25-native-windows-loop-workflows.md
+++ b/.ai/specs/2026-08-25-native-windows-loop-workflows.md
@@ -1,0 +1,33 @@
+# Shell-Neutral Loop Workflows
+
+## TLDR
+
+Remove shell logic from resumable create/continue loops while preserving run-folder and Progress formats.
+
+## Dependency and scope
+
+Depends on config/setup, worktree, tracker, and review-workflow specs. Owns the eight loop references and only the routing text named by the roadmap.
+
+## Proposed solution
+
+Use structured file operations for run state, direct argv processes for child executors, and named tracker operations for claims/finalization. Preserve filenames, fields, resume ordering, commit association, and parsed output exactly.
+
+## Failures
+
+Malformed state, missing executor, failed child process, or claim conflict stops at the existing boundary. Interrupted work remains resumable and cleanup touches only current-run state.
+
+## Validation and plan
+
+1.1 Add shared run-state fixtures and expected semantic/parsed outputs.
+
+1.2 Migrate create-loop helpers; test success, interruption, child failure, and claim conflict on Ubuntu/Windows.
+
+2.1 Migrate continue-loop helpers; test lookup, old-state compatibility, resume, review, and finalization.
+
+2.2 Assert exact argv and that no shell process, pipeline, or evaluated command string is used.
+
+## Completion Criteria
+
+- Both loops complete/resume identically on both OSes.
+- Existing run folders and parsed markers remain compatible.
+- No platform branch or shell dependency remains.

--- a/.ai/specs/2026-08-25-native-windows-qa-bootstrap.md
+++ b/.ai/specs/2026-08-25-native-windows-qa-bootstrap.md
@@ -1,0 +1,32 @@
+# Shell-Neutral QA Bootstrap
+
+## TLDR
+
+Launch test environments from one structured program/argument descriptor instead of choosing `.sh` or `.ps1` orchestration branches.
+
+## Dependency and scope
+
+Depends on config/setup. Owns the additive `test-env.json` `launch` contract and every direct consumer that must change with it: `om-auto-qa-pr/references/boot-env.md`; `om-prepare-test-env/SKILL.md` plus `references/entrypoint-contract.md`, `env-descriptor.md`, and `phase-2-generate.md`; `om-integration-tests/SKILL.md` plus `references/test-env-reuse.md`; and the `test-env.json` section of `BACKWARD_COMPATIBILITY.md`. Existing entrypoints remain compatibility inputs.
+
+## Proposed solution
+
+Read optional `launch.program`, `args`, `cwd`, and environment; validate and invoke directly. The generator chooses a repository-native cross-platform executable when available. If no structured launch exists, use a legacy entrypoint only with an available compatible runner; never translate it or silently select another OS environment.
+
+## Failures
+
+Malformed launch data, missing program, readiness timeout, early exit, and cleanup failure retain current QA classifications/evidence and actionable paths. Cleanup affects only the launched process and owned artifacts.
+
+## Validation and plan
+
+1.1 Specify additive schema/fallback rules and fixtures for structured plus legacy descriptors.
+
+1.2 Update every named producer/consumer in the same PR, then test direct launch, readiness, evidence handoff, timeout, crash, and cleanup on Ubuntu/Windows.
+
+1.3 Assert the structured route starts no shell and preserves all existing descriptor fields.
+
+## Completion Criteria
+
+- One structured launch route works identically on both OSes.
+- Legacy descriptors remain readable and fail cleanly without their runner.
+- Every producer/consumer and the protected-contract document changes together.
+- No full-pipeline PowerShell or Bash prerequisite is introduced.

--- a/.ai/specs/2026-08-25-native-windows-repo-maintenance.md
+++ b/.ai/specs/2026-08-25-native-windows-repo-maintenance.md
@@ -1,0 +1,22 @@
+# Shell-Neutral Upgrade-Notes Application
+
+## TLDR
+
+Remove shell and `jq` logic from `om-apply-upgrade-notes` while preserving descriptor-template authority.
+
+## Dependency and scope
+
+Depends on config/setup. Owns non-standard instructions in `skills/om-apply-upgrade-notes/SKILL.md`; its setup copy remains foundation-owned.
+
+## Proposed solution and validation
+
+Use structured config/file reads and direct argv. Preserve its cross-skill-reference exception, diff presentation, user authority, and mutation boundary. Test absent/current/outdated/malformed descriptors plus preview, accepted/declined update, failure, and cleanup on Ubuntu/Windows.
+
+## Implementation Plan
+
+1.1 Add fixtures/postconditions. 1.2 rewrite reads/apply paths. 1.3 run cross-OS matrix and assert no shell/`jq`.
+
+## Completion Criteria
+
+- Every route behaves identically on both OSes.
+- Template authority and confirmation remain unchanged; no new runtime is added.

--- a/.ai/specs/2026-08-25-native-windows-skill-authoring-gates.md
+++ b/.ai/specs/2026-08-25-native-windows-skill-authoring-gates.md
@@ -1,0 +1,27 @@
+# Shell-Neutral Skill-Authoring Gates
+
+## TLDR
+
+Express skill completeness and reference checks once without shell-language logic.
+
+## Dependency and scope
+
+Depends on config/setup and exclusively owns `skills/om-create-skill/references/gates.md`, `repo-invariants.md`, and `shared-boilerplate.md`.
+
+## Proposed solution
+
+Use structured file discovery/reads and direct executable argument arrays only when a repository command is needed. Preserve gate names, ordering, diagnostics, and exit behavior.
+
+## Validation and plan
+
+1.1 Add fixtures for valid, missing frontmatter, wrong name, missing reference, overlong description, and paths with spaces/Unicode.
+
+1.2 Rewrite owned gate recipes without evaluated command strings or OS branches.
+
+1.3 Assert identical pass/fail classifications and normalized diagnostics on Ubuntu and Windows, with no shell process.
+
+## Completion Criteria
+
+- Every documented authoring gate executes through agent file/process capabilities.
+- Invalid fixtures fail the same gate on both OSes.
+- No frontmatter or skill-layout contract changes.

--- a/.ai/specs/2026-08-25-shell-neutral-check-and-commit.md
+++ b/.ai/specs/2026-08-25-shell-neutral-check-and-commit.md
@@ -1,0 +1,22 @@
+# Shell-Neutral Check and Commit
+
+## TLDR
+
+Remove shell and `jq` logic from `om-check-and-commit` independently.
+
+## Dependency and scope
+
+Depends on config/setup. Owns non-standard `om-check-and-commit` instructions/references; its setup copy remains foundation-owned.
+
+## Proposed solution and validation
+
+Use structured config/status reads and direct validation/Git argv. Preserve dirty-file selection, unrelated-change protection, validation, commit message, and no-push authority. Test clean, selected/unrelated changes, malformed config, validation/commit failure, and success on Ubuntu/Windows.
+
+## Implementation Plan
+
+1.1 Add fixtures/postconditions. 1.2 rewrite owned instructions. 1.3 run cross-OS matrix and assert no shell/`jq`.
+
+## Completion Criteria
+
+- Exact validation and commit scope is preserved on both OSes.
+- No shell, `jq`, or new runtime dependency remains.

--- a/.ai/specs/2026-08-25-shell-neutral-continue-workflow.md
+++ b/.ai/specs/2026-08-25-shell-neutral-continue-workflow.md
@@ -1,0 +1,22 @@
+# Shell-Neutral Continue Workflow
+
+## TLDR
+
+Port `om-auto-continue-pr` as one independently shippable route.
+
+## Dependencies and scope
+
+Depends on config/setup, worktree, and tracker specs. Owns non-standard `om-auto-continue-pr` instructions.
+
+## Proposed solution and validation
+
+Use structured Progress reads, direct validation/Git argv, and named tracker operations. Preserve claim, first-unchecked-step selection, PR reuse, commit association, handback, and chaining. Test complete, resume, no-pending-step, claim-conflict, failed-validation, and interrupted-cleanup routes separately on Ubuntu/Windows.
+
+## Implementation Plan
+
+1.1 Add postconditions/fixtures. 1.2 migrate instructions. 1.3 run the cross-OS matrix and lint.
+
+## Completion Criteria
+
+- Continue/resume and parsed Progress/chaining formats are unchanged.
+- No shell is invoked and only owned state is cleaned.

--- a/.ai/specs/2026-08-25-shell-neutral-review-workflows.md
+++ b/.ai/specs/2026-08-25-shell-neutral-review-workflows.md
@@ -1,0 +1,22 @@
+# Shell-Neutral Review Workflows
+
+## TLDR
+
+Port code review, autonomous review, and PR autopilot as one review/CI-transition capability.
+
+## Dependencies and scope
+
+Depends on config/setup, worktree, and tracker specs. Owns non-standard instructions for `om-code-review`, `om-auto-review-pr`, and `om-pr-autopilot`, including report, CI-follow-up, and label-transition references.
+
+## Proposed solution and validation
+
+Use structured diff/report files, direct validation argv, and named tracker review/label operations. Preserve severity verdicts, self-review restrictions, changes-requested loops, CI follow-up, labels, handback, and cleanup. Test each route on Ubuntu/Windows for approve, findings, failed checks, fork/self-review restriction, retry, and claim conflict.
+
+## Implementation Plan
+
+1.1 Add route postconditions. 1.2 migrate code/auto review. 1.3 migrate autopilot/CI transitions. 1.4 run route-specific matrix.
+
+## Completion Criteria
+
+- All three routes pass success/failure fixtures on both OSes.
+- Review/label/CI semantics remain compatible with no shell branch.

--- a/.ai/specs/2026-08-25-shell-neutral-tracker-operations.md
+++ b/.ai/specs/2026-08-25-shell-neutral-tracker-operations.md
@@ -1,0 +1,23 @@
+# Shell-Neutral Tracker Operations
+
+## TLDR
+
+Rewrite tracker descriptors as one ordered operation model using direct client argv and structured files.
+
+## Dependency and scope
+
+Depends on config/setup. Owns tracker template, shipped GitHub descriptor, repo `.ai/trackers/github.md`, tracker sections of `BACKWARD_COMPATIBILITY.md`, and mock contract tests.
+
+## Proposed solution
+
+For every operation/guard, specify inputs, ordered invocations, parsed result, postcondition, failure, and cleanup. Preserve names/outputs. GitHub uses direct `gh` argv and temporary body/evidence files. Old customized descriptors are never silently overwritten.
+
+## Validation and plan
+
+1.1 Inventory all routes/postconditions. 1.2 update all three descriptors together. 1.3 mock every auth/read/search/claim/PR/comment/label/handback/error/cleanup route on Ubuntu/Windows with exact argv assertions.
+
+## Completion Criteria
+
+- Every named route has cross-OS evidence.
+- Multiline/untrusted data is file-backed and never evaluated.
+- Names, outputs, idempotency, and legacy safety remain compatible.

--- a/.ai/specs/2026-08-25-shell-neutral-worktree-lifecycle.md
+++ b/.ai/specs/2026-08-25-shell-neutral-worktree-lifecycle.md
@@ -1,0 +1,22 @@
+# Shell-Neutral Worktree Lifecycle
+
+## TLDR
+
+Synchronize one direct-Git worktree algorithm across all nine standard copies.
+
+## Dependency and scope
+
+Depends on config/setup. Owns the nine `worktree-setup.md` copies listed in the roadmap and lifecycle fixtures.
+
+## Proposed solution
+
+Express discovery, add/reuse, branch validation, nesting prevention, cleanup ownership, removal, and prune as individual Git argv calls plus decisions—never shell variables, traps, or OS variants.
+
+## Authorization, validation, and plan
+
+1.1 Ask to synchronize the exact nine owners; without approval stop. Build real fixtures. 1.2 synchronize all copies while preserving specifics. 1.3 test create/reuse/interruption/failure/cleanup in spaced Unicode paths on Ubuntu/Windows and machine-check shared equality.
+
+## Completion Criteria
+
+- All copies are authorized and semantically identical.
+- Real lifecycle passes without a shell and never changes primary/unowned worktrees.

--- a/.ai/specs/2026-08-25-windows-compatibility.md
+++ b/.ai/specs/2026-08-25-windows-compatibility.md
@@ -1,0 +1,329 @@
+# Native Windows Compatibility for the Skills Collection
+
+## TLDR
+
+The collection has proven Windows-aware test-environment and browser-provider paths, but the general PR pipeline is not yet runnable from native Windows PowerShell: bootstrap, worktree, tracker, loop, and local validation recipes still assume Bash/POSIX tools. This specification defines an additive PowerShell execution contract and a phased migration that preserves current POSIX behavior and downstream committed configuration.
+
+## Resolved assumptions (autonomous defaults)
+
+- **Supported native environment:** full native-Windows support targets PowerShell 7 (`pwsh`) with Git for Windows and the configured tracker CLI available. Windows PowerShell 5.1 may remain a documented fallback for already-supported isolated flows such as generated test-environment launchers, but it is not the full-pipeline baseline; Microsoft distinguishes the maintained cross-platform PowerShell product from Windows PowerShell 5.1.
+- **Other Windows environments:** Git Bash/MSYS continues through the POSIX execution family; WSL2 continues through the Linux/POSIX family. Native Windows support must not require either one.
+- **Compatibility:** existing config keys, tracker/browser operation names, plan formats, chaining markers, and generated environment descriptor fields remain backward compatible. New metadata and command variants are additive.
+- **Project commands:** the collection guarantees that its own orchestration works in the selected shell. It cannot guarantee that arbitrary target-repository commands are portable; it must select configured shell-specific variants when supplied and report an actionable failure otherwise.
+- **Scope:** this document specifies the work. It does not edit any runtime skill, standard reference, descriptor, or tool implementation.
+
+None of these assumptions requires human confirmation because each is reversible and keeps the current POSIX path intact.
+
+## Problem Statement
+
+The collection advertises installable, repository-agnostic automation, and one important subsystem already claims macOS, Linux, WSL2, Git Bash, and native Windows support. That support does not extend to the full pipeline. A native Windows agent reaches Bash-only instructions before it can configure a repository, create an isolated worktree, call guarded tracker operations, parse loop state, or run this repository's own validation gate.
+
+This is not solved by replacing `bash` with `pwsh` in a few examples. The affected snippets include shell variables, `jq`, process substitution, `/tmp`, POSIX redirects, `trap`, signal/PID handling, text pipelines, and cleanup. PowerShell can invoke native programs such as `git` and `gh`, but its language keywords, quoting, object pipeline, error propagation, path rules, and native-argument behavior differ from Bash. Microsoft explicitly documents shell-language constructs as runtime-specific and warns that native argument passing can differ by PowerShell version.
+
+The result today is a partial compatibility story:
+
+- Test-environment generation and browser provisioning have native Windows paths.
+- Git Bash and WSL can run most of the remaining pipeline as POSIX environments.
+- Native PowerShell cannot reliably run the general pipeline without translating undocumented Bash behavior or installing an additional POSIX shell.
+
+The target outcome is a truthful support claim backed by executable Windows CI evidence.
+
+## Current-state audit
+
+The audit was run against `origin/main` at `69f64b0` on 2026-08-25. Counts are evidence of review surface, not a rule that every Bash block needs a duplicate.
+
+| Surface | Evidence | Native-Windows assessment |
+|---|---:|---|
+| Collection size | 36 skill directories; 279 Markdown files under `skills/` | Broad enough that a per-file ad hoc fix will drift. |
+| Shell examples | 92 fenced Bash blocks in 30 files; 2 fenced PowerShell blocks in 2 files | Compound orchestration is overwhelmingly POSIX-only. |
+| Config loading | 24 skill Markdown files mention `jq`; 15 `agentic-setup.md` copies contain explicit Bash/`jq` mechanics | First-run and per-run setup can fail before the skill's main work begins. |
+| Worktree setup | 9 duplicated `references/worktree-setup.md` files, all with Bash recipes | Every isolated PR workflow needs a native equivalent and synchronized semantics. |
+| Tracker provider | Shipped GitHub descriptor uses Bash guard functions, loops, redirects, temporary files, and variable assignment around otherwise portable `gh` commands | `gh` is available on Windows, but the descriptor glue is not native PowerShell. |
+| Loop/reference helpers | Command-heavy run-folder lookup, executor dispatch, review, label transition, and changelog window references use Bash and `/tmp` | Long-running/resumable variants remain blocked after basic worktree support. |
+| Repository gate | `.ai/agentic.config.json` runs `bash scripts/lint.sh`; `package.json` invokes `scripts/lint.sh`; CI only proves Ubuntu | A native Windows contributor cannot reproduce the configured local gate without Bash. |
+| Developer install | `scripts/install-skills.mjs` creates directory symlinks using `type: "dir"` | Windows symlink creation may require privilege or Developer Mode; Node supports directory junctions as the lower-friction directory-link primitive. |
+| Line endings | No repository `.gitattributes`; generated test-environment guidance already requires LF for `.sh` | Git Bash compatibility and shell-wrapper reliability can regress under `core.autocrlf=true`. |
+
+### Already portable; preserve rather than redesign
+
+- `om-prepare-test-env` already selects `.sh` on POSIX/Git Bash/WSL and `.ps1` on native Windows, defines equivalent entrypoint semantics, handles Windows paths and line endings, and records `platform` in `test-env.json`.
+- `om-integration-tests` already requires matching native POSIX and PowerShell scenario launchers when scaffolding agent-browser tests.
+- The `agent-browser` descriptor ships a native Windows executable path and PowerShell installation recipe; `scripts/test-browser-providers.mjs` covers the Windows asset matrix.
+- PR #18 established the correct pattern: one semantic contract, native implementations, identical output fields, and platform-specific tests. This proposal extends that pattern to the rest of the pipeline instead of changing the test-environment contract again.
+
+### Blocking gaps
+
+1. **P0 — setup bootstrap:** the canonical config-loading recipe assumes Bash and `jq`. A fresh native-Windows repository cannot consistently reach the rest of the workflow.
+2. **P0 — tracker mutations:** the GitHub provider's guards and multi-command operations are Bash programs. Claiming, labeling, creating PRs, preserving multiline bodies, and evidence upload need PowerShell implementations with identical operation outputs.
+3. **P0 — isolated worktrees:** all nine worktree references use Bash conditionals, command substitution, and trap-style cleanup. The core author/reviewer skills therefore cannot honor their isolation contract natively.
+4. **P1 — validation selection:** `validation.commands` has no way to express different shell syntax for the same gate. This repository's configured gate is itself Bash-only.
+5. **P1 — loop and release helpers:** resumable loop engines and changelog reachability use POSIX temp paths and text pipelines.
+6. **P1 — verification gap:** no `windows-latest` job proves that PowerShell examples parse or that the core setup/worktree/tracker contract works without Bash.
+7. **P2 — contributor tooling:** the installer link type, audit script, Codex E2E harness, and missing line-ending policy make Windows development less reliable even after runtime skills are fixed.
+
+### External research and adopted guidance
+
+- The [Agent Skills specification](https://github.com/agentskills/agentskills/blob/main/docs/specification.mdx) says bundled script-language support depends on the agent implementation. Therefore the core installed skills should not introduce a mandatory new Python or Node runtime merely to avoid shell pairing.
+- The official [Agent Skills quickstart](https://github.com/agentskills/agentskills/blob/main/docs/skill-creation/quickstart.mdx) demonstrates adjacent Bash and PowerShell recipes for the same operation. This supports explicit variants for shell-language logic.
+- Microsoft's [running commands in PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/learn/shell/running-commands) guidance distinguishes native executables from shell-specific language keywords. The design keeps simple `git`/`gh` argv calls single-sourced where quoting is identical and pairs compound language logic.
+- Microsoft's [PowerShell parsing guidance](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_parsing) documents platform/version-specific native-argument behavior. The design requires argv-safe calls and tests paths containing spaces instead of promising textual translation.
+- Microsoft's [PowerShell path syntax](https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_path_syntax) notes that slash-agnostic cmdlet paths do not guarantee native applications accept the same separators. Stored contracts remain repo-relative with `/`; execution recipes resolve native paths before passing them to native applications.
+- GitHub's [workflow command documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands) notes that PowerShell 7 uses UTF-8 by default while Windows PowerShell 5.1 does not. The full pipeline baseline is PowerShell 7, and any 5.1 fallback must set encoding explicitly.
+- Node's [filesystem documentation](https://nodejs.org/api/fs.html) defines `junction` as a Windows directory-link type and normalizes its target to an absolute path. The development installer should use junctions on Windows while retaining directory symlinks elsewhere.
+
+## Proposed solution
+
+Adopt one platform execution contract across the collection and implement it in the existing per-skill reference structure.
+
+### 1. Execution-family contract
+
+Every skill preflight resolves one of two execution families before running shell logic:
+
+| Family | Selected when | Required interpreter | Notes |
+|---|---|---|---|
+| `posix` | The active environment provides a POSIX-compatible `sh`; includes macOS, Linux, WSL2, Git Bash/MSYS | POSIX `sh`; Bash only when a recipe explicitly needs it | Current behavior remains valid. |
+| `powershell` | The agent is operating natively on Windows without choosing the POSIX path | PowerShell 7 (`pwsh`) | Must not call `sh`, WSL, Git Bash, `jq`, or POSIX utilities implicitly. |
+
+Rules:
+
+- Use the active environment; do not silently cross from native PowerShell into WSL or Git Bash.
+- Treat `git`, `gh`, `node`, and project CLIs as native executables. A simple argv invocation may be shown once if it parses identically in both families.
+- Any compound recipe using variables, conditionals, loops, pipelines, redirection, temporary files, background jobs, cleanup, or JSON parsing must provide explicit POSIX and PowerShell forms, or move the semantics into an already-required cross-platform executable.
+- PowerShell recipes start with strict failure behavior, check `$LASTEXITCODE` after native commands, and use `try`/`finally` for cleanup. They must not mutate the machine-wide execution policy.
+- Stored paths and cross-skill outputs remain repo-relative with `/`. Resolve to native absolute paths only at the invocation boundary; test spaces, Unicode, drive-letter paths, and long worktree paths.
+- Temporary directories use the platform temp API and include a skill/run-specific suffix. Never hard-code `/tmp` or a drive root.
+- Config JSON uses PowerShell built-ins (`Get-Content -Raw | ConvertFrom-Json`) in the PowerShell family; `jq` remains allowed only on the POSIX path where the recipe declares it.
+- User-facing command examples must match the selected family. Reports name which family ran.
+
+This contract belongs in the shared section of every `references/agentic-setup.md` copy. Because that is a standard file, the implementation must enumerate all skills carrying it and ask whether to synchronize the shared change before editing, as required by `AGENTS.md`.
+
+### 2. Additive validation-command selection
+
+Extend `validation` without removing or changing `commands`:
+
+```json
+{
+  "validation": {
+    "commands": ["node scripts/lint.mjs"],
+    "commandsByShell": {
+      "posix": ["bash scripts/check-generated.sh"],
+      "powershell": ["pwsh -NoProfile -File scripts/check-generated.ps1"]
+    }
+  }
+}
+```
+
+Resolution order:
+
+1. Use the non-empty `validation.commandsByShell.<execution-family>` array when present.
+2. Otherwise use the legacy `validation.commands` array unchanged and execute each command in the active shell.
+3. Treat a syntax/interpreter failure as a gate failure with the exact command, shell family, and remediation. Do not auto-translate repository-owned commands.
+
+`commandsByShell` is optional and additive, so the config schema stays at version 1. Updated setup writes it only when the detected commands genuinely differ. Old skills ignore it and keep using `commands`; updated skills continue to work with old configs. The implementation must update `.ai/agentic.config.json` and `SDLC.md` together in this repository.
+
+### 3. Dual-recipe standard references
+
+Keep the current standalone-install model; do not introduce cross-skill file pointers.
+
+- Add platform selection and config loading to the shared portion of each `agentic-setup.md` copy.
+- Add semantically equivalent PowerShell create/cleanup sections to all nine `worktree-setup.md` copies:
+  - `om-auto-continue-pr-loop`
+  - `om-auto-continue-pr`
+  - `om-auto-create-pr-loop`
+  - `om-auto-create-pr`
+  - `om-auto-fix-issue`
+  - `om-auto-fix-pr`
+  - `om-auto-qa-pr`
+  - `om-auto-review-pr`
+  - `om-auto-write-spec`
+- Preserve exact branch, detached-worktree, reuse, cleanup ownership, and no-nesting semantics. The recipes may differ syntactically but not behaviorally.
+- Keep skill-specific behavior below the marked specifics section. Do not fork the shared contract per skill.
+
+### 4. Platform-aware tracker descriptors
+
+Update `skills/om-setup-agent-pipeline/references/trackers/TEMPLATE.md`, the shipped GitHub descriptor, and this repository's `.ai/trackers/github.md` in the same implementation PR.
+
+Descriptor rules:
+
+- Add a stable `Execution families: posix, powershell` capability line near prerequisites.
+- For shell-neutral single native invocations, document the command once and state the returned value semantically rather than assigning a Bash variable.
+- For guards and compound operations, provide `POSIX` and `PowerShell` subsections with identical inputs, outputs, and failure behavior.
+- Preserve every named operation and guard name. PowerShell functions use the same conceptual guard names (`label_exists`, `apply_label`, and peers) even if PowerShell naming conventions would normally differ; skills refer to the contract names, not language symbols.
+- Multiline bodies always use body files or stdin; no shell-dependent inline quoting.
+- PowerShell temporary evidence files live under the platform temp directory and are removed in `finally`.
+- Existing repo-local descriptor customizations remain authoritative. On native PowerShell, an older descriptor with no PowerShell capability may execute shell-neutral native commands, but a skill must stop before the first compound mutation and point to `om-apply-upgrade-notes`; it must not silently substitute the shipped descriptor or guess around custom operations.
+
+This preserves old descriptors on their existing POSIX path while making the new Windows capability opt-in through an explicit descriptor upgrade.
+
+### 5. Command-heavy reference migration
+
+After setup, worktrees, and tracker operations work, audit the remaining 92 Bash fences. Each block receives one classification:
+
+- `shell-neutral-native`: keep one command form and prove argv/path behavior on both families.
+- `paired-shell-logic`: add a PowerShell recipe with the same semantic output.
+- `posix-project-command`: keep it POSIX-only, state the prerequisite, and define the native-Windows fallback or clean stop.
+- `obsolete`: replace with shell-neutral prose or remove if no skill needs to execute it.
+
+The first migration set includes the command-heavy references found in:
+
+- `om-auto-create-pr-loop` and `om-auto-continue-pr-loop`: executor dispatch, run-folder layout/lookup, step review, claim/finalization helpers.
+- `om-auto-qa-pr`: bootstrap environment handling.
+- `om-auto-review-pr`: label transitions.
+- `om-auto-update-changelog`: release-window reachability and temporary commit sets.
+- `om-create-skill`: completeness and reference gates.
+- `om-setup-agent-pipeline`: skill coverage and provider installation.
+
+The implementation must add a portability lint that reports unclassified executable fences. It should not require meaningless PowerShell duplicates for shell-neutral commands.
+
+### 6. Cross-platform repository tooling
+
+Make this repository itself a reliable Windows fixture:
+
+- Move the authoritative lint implementation to `scripts/lint.mjs`; retain `scripts/lint.sh` as a compatibility wrapper so the protected `bash scripts/lint.sh` entry point continues to work.
+- Change `package.json`, this repository's `validation.commands`, and the primary CI gate to invoke the Node implementation. Update `SDLC.md` with the same command.
+- Port `scripts/audit-skills.sh` to a cross-platform Node implementation or retain it as an Ubuntu-only informational job with an explicitly scoped support statement. The required PR gate must not depend on it.
+- Add a native PowerShell contract harness for setup/config parsing, worktree lifecycle, tracker guard behavior with a mocked CLI, path/quoting, and cleanup.
+- Keep the existing POSIX Codex E2E harness; add a native Windows smoke path or a provider-contract fixture that exercises `.ps1` without invoking `sh`.
+- In `scripts/install-skills.mjs`, use a directory junction on Windows and the existing directory symlink elsewhere. Preserve all flags, ownership detection, force behavior, and uninstall behavior; add tests for both strategies.
+- Add `.gitattributes` at minimum for `*.sh text eol=lf` and `*.ps1 text`, matching the already-shipped generated-script guidance.
+
+### 7. Support matrix and documentation
+
+Document the result in `README.md` and `DECISIONS.md` only after CI proves it:
+
+| Environment | Expected status after implementation |
+|---|---|
+| macOS/Linux POSIX | Fully supported; no behavior regression. |
+| WSL2 | Fully supported through POSIX family. |
+| Windows + Git Bash/MSYS | Fully supported through POSIX family; LF policy enforced. |
+| Native Windows + PowerShell 7 | Fully supported for setup, PR pipeline, review, QA orchestration, and local repository gate. |
+| Native Windows + Windows PowerShell 5.1 only | Limited compatibility for explicitly documented legacy flows; full pipeline preflight requests PowerShell 7. |
+
+Do not use “works on Windows” without naming the tested shell and prerequisites.
+
+## Contract and Compatibility Review
+
+| Protected surface | Change | Compatibility treatment |
+|---|---|---|
+| Skill names/layout | None | No renames, aliases, or directory moves. |
+| Config schema | Add optional `validation.commandsByShell` | Version remains 1; legacy `commands` stays the fallback and is never removed. |
+| Tracker operations/guards | Add execution-family recipes and capability marker | Names, inputs, outputs, and semantics remain identical; template and shipped/repo descriptors update together. |
+| Browser operations | No semantic change | Existing Windows implementation is retained and reused as precedent. |
+| Cross-skill files | No format change | Progress, tracking-plan lines, chaining references, and `test-env.json` remain unchanged. |
+| Label taxonomy | None | No label additions, removals, or semantic changes. |
+| Installer CLI | Internal Windows link strategy change | Existing scripts/flags/output remain; ownership detection accepts junctions created by this repository. |
+| Lint CLI | Add Node implementation | `scripts/lint.sh` remains as a wrapper for existing callers. |
+
+No migration may require consumer repositories to regenerate `.ai/agentic.config.json`. Descriptor upgrades are needed only to enable native PowerShell mutations; POSIX use of older descriptors remains unchanged.
+
+## Edge Cases and Failure Scenarios
+
+| Scenario | Required behavior |
+|---|---|
+| Repository path contains spaces or Unicode | All setup, worktree, body-file, and validation operations succeed; no string-built command line is evaluated. |
+| Windows drive or UNC path | Resolve with platform APIs; never concatenate a POSIX root or assume `C:` is part of a shell token. If Git worktrees do not support the resolved target, stop before mutation with the exact path and Git error. |
+| Only Windows PowerShell 5.1 is installed | Full-pipeline preflight stops with a PowerShell 7 prerequisite; already-supported 5.1 flows keep their explicit encoding/execution-policy fallback. |
+| `gh` or tracker CLI missing | The descriptor's auth/prerequisite check fails before claims or partial label mutations. |
+| Old repo-local tracker descriptor on PowerShell | Execute only shell-neutral reads that are unambiguous; stop before compound mutation and name the descriptor upgrade path. Never replace custom content silently. |
+| Only legacy `validation.commands` exists | Execute it in the active shell. On shell syntax failure, fail the gate and recommend adding `commandsByShell`; never report success based on a translated guess. |
+| PowerShell native command returns non-zero without throwing | Recipe checks `$LASTEXITCODE` and fails; `$ErrorActionPreference` alone is insufficient. |
+| Interrupted worktree run | `finally` removes only the worktree created by that run and prunes metadata; the user's primary checkout and pre-existing worktrees remain untouched. |
+| `core.autocrlf=true` | `.sh` files retain LF; PowerShell files remain readable; CI validates line endings. |
+| Windows symlink privilege unavailable | Development installer uses a junction and does not request elevation or Developer Mode. |
+| Shell families produce different text/JSON | Contract tests compare normalized semantic outputs, not cosmetic whitespace. Parsed markers remain byte-compatible where consumers require exact lines. |
+
+## Security and Safety Review
+
+- Do not loosen the untrusted-content boundary while adding platform recipes.
+- Never use `Invoke-Expression`, `cmd /c` string construction, or PowerShell's stop-parsing token as a general quoting workaround. Pass arguments as arrays/native argv.
+- Do not change machine-wide execution policy, enable Developer Mode, request elevation, or install WSL/Git Bash automatically.
+- Preserve the exact destructive-action scope of cleanup. PowerShell `Remove-Item -Recurse -Force` is allowed only for an explicitly resolved, run-owned temporary/worktree path after validation; broad roots and unresolved variables remain forbidden.
+- Tracker body and evidence operations continue using files/stdin to prevent interpolation and secret leakage.
+
+## Validation Strategy
+
+### Static gates
+
+- Existing frontmatter, product-agnosticism, reference resolution, roster, and tracker-abstraction assertions run through `node scripts/lint.mjs` on Ubuntu and Windows.
+- A portability check inventories executable Markdown fences and rejects any new compound Bash block that lacks a classification or PowerShell pair.
+- Parse every committed/generated `.ps1` fixture with PowerShell's parser; parse POSIX scripts with the current shell gate.
+- Verify `.gitattributes` line-ending policy.
+
+### Windows execution matrix
+
+Add a `windows-latest` CI job whose `run` steps use `shell: pwsh` and never invoke Bash:
+
+1. Load minimal, full, and legacy `.ai/agentic.config.json` fixtures; resolve defaults and `commandsByShell` correctly.
+2. Create and clean an isolated Git worktree in a path containing spaces; assert the primary worktree is unchanged.
+3. Exercise GitHub descriptor guard functions against a mock `gh` executable/function: missing label degrades, disabled labels no-op, pipeline labels remain exclusive, multiline bodies preserve formatting, and non-zero exits fail.
+4. Verify run-folder and temporary-file helpers with native temp paths.
+5. Run the Node lint and browser-provider platform matrix.
+6. Install and uninstall fixture skills through Windows junctions without elevation.
+7. Execute a PowerShell test-environment/provider fixture and assert no `sh`, WSL, Git Bash, `jq`, or POSIX utility is launched.
+
+### Regression matrix
+
+- Keep an Ubuntu POSIX job running the compatibility wrapper `bash scripts/lint.sh` and representative POSIX recipes.
+- Add a Windows Git Bash lane only for the LF/Git-Bash support claim; it is not evidence for native PowerShell.
+- Require both native Windows and POSIX jobs before the support claim is published.
+
+## Risks & Impact Review
+
+- **Highest risk — duplicated standard files:** platform policy and worktree logic can drift across skills. Mitigation: synchronize all copies in one implementation PR, machine-check shared sections, and follow the repository's mandatory ask-before-sync rule.
+- **High risk — tracker parity:** a PowerShell guard that partially mutates labels or claims before failing could corrupt pipeline state. Mitigation: mock-driven operation tests and identical postconditions for both families.
+- **Medium risk — config precedence:** updated and old skills may choose different validation arrays. Mitigation: additive fallback order, documentation, and no removal of `commands` until a future versioned migration (not proposed here).
+- **Medium risk — documentation size:** naively pairing all 92 Bash blocks would inflate token cost. Mitigation: pair only compound shell logic, keep native argv commands single-sourced, and push detail into the existing per-skill references.
+- **Medium risk — PowerShell version behavior:** quoting and encoding differ between 5.1 and 7. Mitigation: one full-pipeline baseline (7), explicit limited 5.1 status, and CI on the baseline.
+- **Low risk — developer tooling migration:** moving lint logic to Node can change edge-case output. Mitigation: golden tests comparing current lint fixtures and retaining the Bash wrapper.
+
+Rollback is phase-local: revert the relevant phase commits. Because config additions are optional and no existing format is rewritten, reverting leaves legacy POSIX consumers functional. Consumer repos that copied a newer descriptor retain an additive PowerShell section that older skills ignore.
+
+## Phasing
+
+### Phase 1: Platform contract and cross-platform gate
+
+Ship the execution-family policy, additive validation schema, Node lint implementation plus Bash wrapper, Windows junction installer behavior, `.gitattributes`, and initial Windows CI fixtures. This phase makes the repository's own portability requirements executable without claiming the full skill pipeline is ready.
+
+### Phase 2: Core PR pipeline on PowerShell
+
+Synchronize agentic setup and all nine worktree standard references; add PowerShell tracker descriptor implementations; migrate the core author/reviewer paths (`om-auto-create-pr`, continue, fix, review, open PR, setup). Prove an end-to-end fixture can plan, worktree, validate, and prepare tracker mutations natively.
+
+### Phase 3: Loop, QA, release, and authoring coverage
+
+Migrate command-heavy loop, QA bootstrap, changelog, create-skill, and coverage references; complete the 92-fence classification; add regression lint; publish the support matrix only when all lanes pass.
+
+Each phase is independently shippable and preserves the POSIX pipeline.
+
+## Implementation Plan
+
+### Phase 1: Platform contract and repository gate
+
+1. Document the `posix`/`powershell` execution-family contract and PowerShell 7 baseline in `AGENTS.md`, `DECISIONS.md`, and the setup skill's schema/reference material; add `validation.commandsByShell` with legacy fallback and update `.ai/agentic.config.json` plus `SDLC.md` together.
+2. Reimplement the lint gate in `scripts/lint.mjs`, retain `scripts/lint.sh` as a wrapper, switch package/config/CI callers to Node, and add golden lint fixtures.
+3. Make `scripts/install-skills.mjs` use Windows junctions with ownership-safe uninstall; add `.gitattributes` and cross-platform installer tests.
+4. Add the `windows-latest` PowerShell contract job and a portability-fence inventory that initially reports the Phase 2/3 backlog without blocking unchanged legacy files.
+
+### Phase 2: Core pipeline recipes
+
+1. Before editing standard references, enumerate every affected `agentic-setup.md` and `worktree-setup.md` owner and obtain the repository-required synchronization decision; record it in the implementation plan/PR.
+2. Synchronize platform selection and native config loading across all affected `agentic-setup.md` copies, preserving skill-specific sections.
+3. Add equivalent PowerShell worktree create/reuse/cleanup recipes to all nine standard `worktree-setup.md` copies and add path-with-spaces lifecycle tests.
+4. Add execution-family capability and PowerShell implementations to the tracker template, shipped GitHub descriptor, and repo descriptor; test guarded reads/mutations against a mock CLI.
+5. Update the setup, create/continue, fix, open-PR, and review workflows to select recipes mechanically and report the execution family; run a native Windows end-to-end fixture and the full POSIX regression gate.
+
+### Phase 3: Complete collection coverage
+
+1. Classify every executable Bash fence and migrate the loop/run-folder/step-review references for create/continue loop skills.
+2. Migrate QA bootstrap, review label transitions, changelog release-window, create-skill gates, setup coverage, and remaining command-heavy outliers.
+3. Port or explicitly scope informational developer scripts, add the native PowerShell provider/test-environment smoke path, and turn the portability inventory into a blocking lint rule for new regressions.
+4. Re-run all Windows and POSIX gates, verify protected contracts and standard-file synchronization, then update README support claims and release notes.
+
+## Completion Criteria
+
+- A native `windows-latest` PowerShell job completes setup/config loading, worktree lifecycle, tracker guard fixtures, validation selection, lint, installer, and provider smoke tests without invoking Bash, WSL, Git Bash, `jq`, or POSIX utilities.
+- Representative `om-auto-create-pr` and `om-auto-review-pr` fixture runs reach their expected tracker-operation boundary using only the PowerShell family and preserve exact Progress/chaining formats.
+- All nine worktree copies and all affected agentic-setup shared sections are synchronized, with the required user sync decision documented.
+- Updated and legacy configs both resolve validation commands correctly; older descriptors continue on POSIX and fail cleanly with an upgrade path on native PowerShell before mutation.
+- `bash scripts/lint.sh` remains green and behavior-compatible; `node scripts/lint.mjs` is the authoritative cross-platform gate.
+- README claims native Windows support only after required Windows CI is green.
+- No protected contract listed in `BACKWARD_COMPATIBILITY.md` is renamed, removed, or made mandatory without a fallback.

--- a/.ai/specs/2026-08-25-windows-compatibility.md
+++ b/.ai/specs/2026-08-25-windows-compatibility.md
@@ -1,329 +1,215 @@
-# Native Windows Compatibility for the Skills Collection
+# Shell-Neutral Compatibility Audit and Roadmap
 
 ## TLDR
 
-The collection has proven Windows-aware test-environment and browser-provider paths, but the general PR pipeline is not yet runnable from native Windows PowerShell: bootstrap, worktree, tracker, loop, and local validation recipes still assume Bash/POSIX tools. This specification defines an additive PowerShell execution contract and a phased migration that preserves current POSIX behavior and downstream committed configuration.
+Changes are required for native Windows, but maintaining Bash and PowerShell branches would make the collection larger and easier to drift. The target is one shell-neutral orchestration model: agents read structured files directly and invoke required executables with a program plus argument array. Git is a pipeline prerequisite; each tracker descriptor declares its own client (GitHub uses `gh`). Node is used only by this repository’s tooling, where it is already a project prerequisite. Python and PowerShell 7 do not become collection-wide dependencies.
 
-## Resolved assumptions (autonomous defaults)
+## Resolved assumptions
 
-- **Supported native environment:** full native-Windows support targets PowerShell 7 (`pwsh`) with Git for Windows and the configured tracker CLI available. Windows PowerShell 5.1 may remain a documented fallback for already-supported isolated flows such as generated test-environment launchers, but it is not the full-pipeline baseline; Microsoft distinguishes the maintained cross-platform PowerShell product from Windows PowerShell 5.1.
-- **Other Windows environments:** Git Bash/MSYS continues through the POSIX execution family; WSL2 continues through the Linux/POSIX family. Native Windows support must not require either one.
-- **Compatibility:** existing config keys, tracker/browser operation names, plan formats, chaining markers, and generated environment descriptor fields remain backward compatible. New metadata and command variants are additive.
-- **Project commands:** the collection guarantees that its own orchestration works in the selected shell. It cannot guarantee that arbitrary target-repository commands are portable; it must select configured shell-specific variants when supplied and report an actionable failure otherwise.
-- **Scope:** this document specifies the work. It does not edit any runtime skill, standard reference, descriptor, or tool implementation.
-
-None of these assumptions requires human confirmation because each is reversible and keeps the current POSIX path intact.
+- **One algorithm:** skills describe semantic steps once. They do not contain paired Bash/PowerShell control flow.
+- **Agent capabilities:** the executor must support structured file read/write, temporary-file creation, process invocation with separate program/arguments/cwd/environment, exit status, and cleanup. If one is unavailable, preflight stops before mutation.
+- **External prerequisites:** Git is required for Git workflows. A tracker client is required only by its descriptor; the shipped GitHub provider uses `gh`. Neither Node nor Python is required by installed runtime skills.
+- **Repository tooling:** this source repository already uses Node, so its lint/audit/installer/E2E tools may use dependency-free Node scripts.
+- **Legacy compatibility:** current string-based validation commands and shell entrypoints remain readable. New structured forms are additive; old formats are not silently translated.
+- **Deliverable:** this PR contains analysis and specifications only.
 
 ## Problem Statement
 
-The collection advertises installable, repository-agnostic automation, and one important subsystem already claims macOS, Linux, WSL2, Git Bash, and native Windows support. That support does not extend to the full pipeline. A native Windows agent reaches Bash-only instructions before it can configure a repository, create an isolated worktree, call guarded tracker operations, parse loop state, or run this repository's own validation gate.
+The collection’s browser/test-environment subsystem already has Windows paths, but the general pipeline embeds shell-language programs for config loading, worktree cleanup, tracker guards, loops, and validation. Native Windows cannot execute most of that without a POSIX layer, while duplicating every block in PowerShell would create two implementations of the same pipeline.
 
-This is not solved by replacing `bash` with `pwsh` in a few examples. The affected snippets include shell variables, `jq`, process substitution, `/tmp`, POSIX redirects, `trap`, signal/PID handling, text pipelines, and cleanup. PowerShell can invoke native programs such as `git` and `gh`, but its language keywords, quoting, object pipeline, error propagation, path rules, and native-argument behavior differ from Bash. Microsoft explicitly documents shell-language constructs as runtime-specific and warns that native argument passing can differ by PowerShell version.
-
-The result today is a partial compatibility story:
-
-- Test-environment generation and browser provisioning have native Windows paths.
-- Git Bash and WSL can run most of the remaining pipeline as POSIX environments.
-- Native PowerShell cannot reliably run the general pipeline without translating undocumented Bash behavior or installing an additional POSIX shell.
-
-The target outcome is a truthful support claim backed by executable Windows CI evidence.
+The durable boundary is not “which shell is active?” It is “which semantic operation is needed?” Git and tracker operations already have stable executable interfaces, and agents already read/write files. Shell syntax is accidental glue that can be removed.
 
 ## Current-state audit
 
-The audit was run against `origin/main` at `69f64b0` on 2026-08-25. Counts are evidence of review surface, not a rule that every Bash block needs a duplicate.
+Audit baseline: `origin/main` at `69f64b0`, 2026-08-25.
 
-| Surface | Evidence | Native-Windows assessment |
+| Surface | Evidence | Assessment |
 |---|---:|---|
-| Collection size | 36 skill directories; 279 Markdown files under `skills/` | Broad enough that a per-file ad hoc fix will drift. |
-| Shell examples | 92 fenced Bash blocks in 30 files; 2 fenced PowerShell blocks in 2 files | Compound orchestration is overwhelmingly POSIX-only. |
-| Config loading | 24 skill Markdown files mention `jq`; 15 `agentic-setup.md` copies contain explicit Bash/`jq` mechanics | First-run and per-run setup can fail before the skill's main work begins. |
-| Worktree setup | 9 duplicated `references/worktree-setup.md` files, all with Bash recipes | Every isolated PR workflow needs a native equivalent and synchronized semantics. |
-| Tracker provider | Shipped GitHub descriptor uses Bash guard functions, loops, redirects, temporary files, and variable assignment around otherwise portable `gh` commands | `gh` is available on Windows, but the descriptor glue is not native PowerShell. |
-| Loop/reference helpers | Command-heavy run-folder lookup, executor dispatch, review, label transition, and changelog window references use Bash and `/tmp` | Long-running/resumable variants remain blocked after basic worktree support. |
-| Repository gate | `.ai/agentic.config.json` runs `bash scripts/lint.sh`; `package.json` invokes `scripts/lint.sh`; CI only proves Ubuntu | A native Windows contributor cannot reproduce the configured local gate without Bash. |
-| Developer install | `scripts/install-skills.mjs` creates directory symlinks using `type: "dir"` | Windows symlink creation may require privilege or Developer Mode; Node supports directory junctions as the lower-friction directory-link primitive. |
-| Line endings | No repository `.gitattributes`; generated test-environment guidance already requires LF for `.sh` | Git Bash compatibility and shell-wrapper reliability can regress under `core.autocrlf=true`. |
-
-### Already portable; preserve rather than redesign
-
-- `om-prepare-test-env` already selects `.sh` on POSIX/Git Bash/WSL and `.ps1` on native Windows, defines equivalent entrypoint semantics, handles Windows paths and line endings, and records `platform` in `test-env.json`.
-- `om-integration-tests` already requires matching native POSIX and PowerShell scenario launchers when scaffolding agent-browser tests.
-- The `agent-browser` descriptor ships a native Windows executable path and PowerShell installation recipe; `scripts/test-browser-providers.mjs` covers the Windows asset matrix.
-- PR #18 established the correct pattern: one semantic contract, native implementations, identical output fields, and platform-specific tests. This proposal extends that pattern to the rest of the pipeline instead of changing the test-environment contract again.
+| Collection | 36 skills; 279 Markdown files | Shared mechanics need one contract. |
+| Shell blocks | 92 Bash fences in 30 files; 2 PowerShell fences in 2 files | Control flow is overwhelmingly shell-coupled. |
+| Config | 24 skill Markdown files mention `jq` | Structured reads are unnecessarily delegated to a CLI. |
+| Worktrees | 9 copied `worktree-setup.md` files use Bash | Git operations are portable; surrounding shell logic is not. |
+| Tracker | GitHub descriptor wraps `gh` in Bash guards/functions | Provider operations can instead be ordered semantic steps. |
+| Repository gate | Required lint invokes `bash scripts/lint.sh`; CI is Ubuntu-only | Native Windows cannot reproduce the gate without Bash. |
+| Installer | Node uses directory symlink type | Windows should use a directory junction without elevation. |
+| Existing Windows work | prepare-test-env/provider paths already handle Windows | Preserve as legacy input while moving toward structured launch. |
 
 ### Blocking gaps
 
-1. **P0 — setup bootstrap:** the canonical config-loading recipe assumes Bash and `jq`. A fresh native-Windows repository cannot consistently reach the rest of the workflow.
-2. **P0 — tracker mutations:** the GitHub provider's guards and multi-command operations are Bash programs. Claiming, labeling, creating PRs, preserving multiline bodies, and evidence upload need PowerShell implementations with identical operation outputs.
-3. **P0 — isolated worktrees:** all nine worktree references use Bash conditionals, command substitution, and trap-style cleanup. The core author/reviewer skills therefore cannot honor their isolation contract natively.
-4. **P1 — validation selection:** `validation.commands` has no way to express different shell syntax for the same gate. This repository's configured gate is itself Bash-only.
-5. **P1 — loop and release helpers:** resumable loop engines and changelog reachability use POSIX temp paths and text pipelines.
-6. **P1 — verification gap:** no `windows-latest` job proves that PowerShell examples parse or that the core setup/worktree/tracker contract works without Bash.
-7. **P2 — contributor tooling:** the installer link type, audit script, Codex E2E harness, and missing line-ending policy make Windows development less reliable even after runtime skills are fixed.
-
-### External research and adopted guidance
-
-- The [Agent Skills specification](https://github.com/agentskills/agentskills/blob/main/docs/specification.mdx) says bundled script-language support depends on the agent implementation. Therefore the core installed skills should not introduce a mandatory new Python or Node runtime merely to avoid shell pairing.
-- The official [Agent Skills quickstart](https://github.com/agentskills/agentskills/blob/main/docs/skill-creation/quickstart.mdx) demonstrates adjacent Bash and PowerShell recipes for the same operation. This supports explicit variants for shell-language logic.
-- Microsoft's [running commands in PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/learn/shell/running-commands) guidance distinguishes native executables from shell-specific language keywords. The design keeps simple `git`/`gh` argv calls single-sourced where quoting is identical and pairs compound language logic.
-- Microsoft's [PowerShell parsing guidance](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_parsing) documents platform/version-specific native-argument behavior. The design requires argv-safe calls and tests paths containing spaces instead of promising textual translation.
-- Microsoft's [PowerShell path syntax](https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_path_syntax) notes that slash-agnostic cmdlet paths do not guarantee native applications accept the same separators. Stored contracts remain repo-relative with `/`; execution recipes resolve native paths before passing them to native applications.
-- GitHub's [workflow command documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands) notes that PowerShell 7 uses UTF-8 by default while Windows PowerShell 5.1 does not. The full pipeline baseline is PowerShell 7, and any 5.1 fallback must set encoding explicitly.
-- Node's [filesystem documentation](https://nodejs.org/api/fs.html) defines `junction` as a Windows directory-link type and normalizes its target to an absolute path. The development installer should use junctions on Windows while retaining directory symlinks elsewhere.
+1. **P0:** config bootstrap requires shell plus `jq`.
+2. **P0:** worktree and tracker safety logic is expressed as shell programs.
+3. **P1:** loop/release/authoring helpers use pipelines, `/tmp`, and shell variables.
+4. **P1:** validation commands are opaque shell strings.
+5. **P1:** test-environment launch is selected by `.sh` versus `.ps1` rather than a structured process descriptor.
+6. **P2:** lint, audit, E2E, installer links, and line endings are not proven on Windows.
 
 ## Proposed solution
 
-Adopt one platform execution contract across the collection and implement it in the existing per-skill reference structure.
+### 1. Shell-neutral operation contract
 
-### 1. Execution-family contract
+Every executable instruction is one of:
 
-Every skill preflight resolves one of two execution families before running shell logic:
-
-| Family | Selected when | Required interpreter | Notes |
-|---|---|---|---|
-| `posix` | The active environment provides a POSIX-compatible `sh`; includes macOS, Linux, WSL2, Git Bash/MSYS | POSIX `sh`; Bash only when a recipe explicitly needs it | Current behavior remains valid. |
-| `powershell` | The agent is operating natively on Windows without choosing the POSIX path | PowerShell 7 (`pwsh`) | Must not call `sh`, WSL, Git Bash, `jq`, or POSIX utilities implicitly. |
+- `file`: read, parse, write, move, or delete an explicitly resolved file through agent filesystem capabilities;
+- `process`: invoke one executable with an argument array, cwd, optional environment map, and checked exit status;
+- `tracker`: execute a named descriptor operation whose implementation is an ordered sequence of `file` and `process` steps;
+- `decision`: evaluate documented inputs and postconditions in the skill algorithm.
 
 Rules:
 
-- Use the active environment; do not silently cross from native PowerShell into WSL or Git Bash.
-- Treat `git`, `gh`, `node`, and project CLIs as native executables. A simple argv invocation may be shown once if it parses identically in both families.
-- Any compound recipe using variables, conditionals, loops, pipelines, redirection, temporary files, background jobs, cleanup, or JSON parsing must provide explicit POSIX and PowerShell forms, or move the semantics into an already-required cross-platform executable.
-- PowerShell recipes start with strict failure behavior, check `$LASTEXITCODE` after native commands, and use `try`/`finally` for cleanup. They must not mutate the machine-wide execution policy.
-- Stored paths and cross-skill outputs remain repo-relative with `/`. Resolve to native absolute paths only at the invocation boundary; test spaces, Unicode, drive-letter paths, and long worktree paths.
-- Temporary directories use the platform temp API and include a skill/run-specific suffix. Never hard-code `/tmp` or a drive root.
-- Config JSON uses PowerShell built-ins (`Get-Content -Raw | ConvertFrom-Json`) in the PowerShell family; `jq` remains allowed only on the POSIX path where the recipe declares it.
-- User-facing command examples must match the selected family. Reports name which family ran.
+- Never use shell variables, command substitution, pipelines, redirects, traps, `eval`, `Invoke-Expression`, or string-built command lines for orchestration.
+- Pass untrusted values only as argument elements or file contents. Use temporary body/evidence files for multiline tracker input.
+- Temporary paths come from the agent’s temp-file capability and are deleted in a guaranteed cleanup step.
+- Simple examples show `program` and `args`, not a command string. Human-readable CLI rendering may be displayed but is not executable input.
+- Git paths remain repo-relative with `/` in committed contracts; resolve native absolute paths only as a process argument.
+- Reports name invoked executable versions, not a “shell family.”
 
-This contract belongs in the shared section of every `references/agentic-setup.md` copy. Because that is a standard file, the implementation must enumerate all skills carrying it and ask whether to synchronize the shared change before editing, as required by `AGENTS.md`.
+Preflight checks agent capabilities, Git, and the selected tracker client before claims or writes. `cmd.exe`, PowerShell, Bash, WSL, Node, and Python are not probed or selected for orchestration.
 
-### 2. Additive validation-command selection
+### 2. Structured validation steps
 
-Extend `validation` without removing or changing `commands`:
+Add an optional version-1-compatible form:
 
 ```json
 {
   "validation": {
-    "commands": ["node scripts/lint.mjs"],
-    "commandsByShell": {
-      "posix": ["bash scripts/check-generated.sh"],
-      "powershell": ["pwsh -NoProfile -File scripts/check-generated.ps1"]
-    }
+    "steps": [
+      { "program": "node", "args": ["scripts/lint.mjs"] },
+      { "program": "git", "args": ["diff", "--check"] }
+    ],
+    "commands": ["bash scripts/lint.sh"]
   }
 }
 ```
 
-Resolution order:
+Resolution:
 
-1. Use the non-empty `validation.commandsByShell.<execution-family>` array when present.
-2. Otherwise use the legacy `validation.commands` array unchanged and execute each command in the active shell.
-3. Treat a syntax/interpreter failure as a gate failure with the exact command, shell family, and remediation. Do not auto-translate repository-owned commands.
+1. If `validation.steps` is present, require a non-empty array of objects with a non-empty `program`, string-array `args`, and optional repo-relative `cwd`/string environment map. Invoke each directly in order.
+2. Otherwise retain legacy `validation.commands`. Run it only when the active agent provides a compatible legacy command runner; if not, stop and ask the repository to add structured steps.
+3. Never translate a command string or introduce platform-specific arrays.
 
-`commandsByShell` is optional and additive, so the config schema stays at version 1. Updated setup writes it only when the detected commands genuinely differ. Old skills ignore it and keep using `commands`; updated skills continue to work with old configs. The implementation must update `.ai/agentic.config.json` and `SDLC.md` together in this repository.
+`commands` remains for old consumers; updated skills prefer `steps`. The repository updates `.ai/agentic.config.json` and `SDLC.md` together.
 
-### 3. Dual-recipe standard references
+### 3. Config, worktree, and tracker semantics
 
-Keep the current standalone-install model; do not introduce cross-skill file pointers.
+- Replace `jq` snippets with instructions to parse JSON as structured data and validate named fields/types.
+- Express worktree setup as individual Git invocations and explicit decision/cleanup steps. All nine standard copies retain identical semantics and shared text.
+- Rewrite tracker descriptors as operation tables: inputs, ordered direct invocations, parsed output, guard, postcondition, failure, cleanup. Preserve every operation/guard name.
+- An old shell-based descriptor remains usable where its legacy runner exists. Otherwise stop before compound mutation and point to `om-apply-upgrade-notes`; never replace custom content silently.
 
-- Add platform selection and config loading to the shared portion of each `agentic-setup.md` copy.
-- Add semantically equivalent PowerShell create/cleanup sections to all nine `worktree-setup.md` copies:
-  - `om-auto-continue-pr-loop`
-  - `om-auto-continue-pr`
-  - `om-auto-create-pr-loop`
-  - `om-auto-create-pr`
-  - `om-auto-fix-issue`
-  - `om-auto-fix-pr`
-  - `om-auto-qa-pr`
-  - `om-auto-review-pr`
-  - `om-auto-write-spec`
-- Preserve exact branch, detached-worktree, reuse, cleanup ownership, and no-nesting semantics. The recipes may differ syntactically but not behaviorally.
-- Keep skill-specific behavior below the marked specifics section. Do not fork the shared contract per skill.
+### 4. Structured launch descriptors
 
-### 4. Platform-aware tracker descriptors
+Add an optional launch object to `test-env.json` while preserving `.sh`/`.ps1` entrypoints:
 
-Update `skills/om-setup-agent-pipeline/references/trackers/TEMPLATE.md`, the shipped GitHub descriptor, and this repository's `.ai/trackers/github.md` in the same implementation PR.
+```json
+{
+  "launch": {
+    "program": "node",
+    "args": ["scripts/start-test-env.mjs"],
+    "cwd": "."
+  }
+}
+```
 
-Descriptor rules:
+The program is repository-selected and need not be Node. Updated QA uses `launch` when present and invokes it directly. Legacy descriptors continue through their existing entrypoint when a compatible runner exists. Generators prefer a repository-native cross-platform executable; if none exists, they may retain legacy platform entrypoints and must state the limitation.
 
-- Add a stable `Execution families: posix, powershell` capability line near prerequisites.
-- For shell-neutral single native invocations, document the command once and state the returned value semantically rather than assigning a Bash variable.
-- For guards and compound operations, provide `POSIX` and `PowerShell` subsections with identical inputs, outputs, and failure behavior.
-- Preserve every named operation and guard name. PowerShell functions use the same conceptual guard names (`label_exists`, `apply_label`, and peers) even if PowerShell naming conventions would normally differ; skills refer to the contract names, not language symbols.
-- Multiline bodies always use body files or stdin; no shell-dependent inline quoting.
-- PowerShell temporary evidence files live under the platform temp directory and are removed in `finally`.
-- Existing repo-local descriptor customizations remain authoritative. On native PowerShell, an older descriptor with no PowerShell capability may execute shell-neutral native commands, but a skill must stop before the first compound mutation and point to `om-apply-upgrade-notes`; it must not silently substitute the shipped descriptor or guess around custom operations.
+### 5. Repository tooling
 
-This preserves old descriptors on their existing POSIX path while making the new Windows capability opt-in through an explicit descriptor upgrade.
+This repository consolidates its own tooling in dependency-free Node because Node is already required here:
 
-### 5. Command-heavy reference migration
+- authoritative `scripts/lint.mjs`, with `scripts/lint.sh` retained as a protected compatibility wrapper;
+- Node security-audit and native E2E harnesses;
+- Windows junction installation;
+- `.gitattributes` and required Ubuntu/Windows Node gates.
 
-After setup, worktrees, and tracker operations work, audit the remaining 92 Bash fences. Each block receives one classification:
+This choice does not impose Node on installed skills or target repositories.
 
-- `shell-neutral-native`: keep one command form and prove argv/path behavior on both families.
-- `paired-shell-logic`: add a PowerShell recipe with the same semantic output.
-- `posix-project-command`: keep it POSIX-only, state the prerequisite, and define the native-Windows fallback or clean stop.
-- `obsolete`: replace with shell-neutral prose or remove if no skill needs to execute it.
+## Compatibility and safety
 
-The first migration set includes the command-heavy references found in:
-
-- `om-auto-create-pr-loop` and `om-auto-continue-pr-loop`: executor dispatch, run-folder layout/lookup, step review, claim/finalization helpers.
-- `om-auto-qa-pr`: bootstrap environment handling.
-- `om-auto-review-pr`: label transitions.
-- `om-auto-update-changelog`: release-window reachability and temporary commit sets.
-- `om-create-skill`: completeness and reference gates.
-- `om-setup-agent-pipeline`: skill coverage and provider installation.
-
-The implementation must add a portability lint that reports unclassified executable fences. It should not require meaningless PowerShell duplicates for shell-neutral commands.
-
-### 6. Cross-platform repository tooling
-
-Make this repository itself a reliable Windows fixture:
-
-- Move the authoritative lint implementation to `scripts/lint.mjs`; retain `scripts/lint.sh` as a compatibility wrapper so the protected `bash scripts/lint.sh` entry point continues to work.
-- Change `package.json`, this repository's `validation.commands`, and the primary CI gate to invoke the Node implementation. Update `SDLC.md` with the same command.
-- Port `scripts/audit-skills.sh` to a cross-platform Node implementation or retain it as an Ubuntu-only informational job with an explicitly scoped support statement. The required PR gate must not depend on it.
-- Add a native PowerShell contract harness for setup/config parsing, worktree lifecycle, tracker guard behavior with a mocked CLI, path/quoting, and cleanup.
-- Keep the existing POSIX Codex E2E harness; add a native Windows smoke path or a provider-contract fixture that exercises `.ps1` without invoking `sh`.
-- In `scripts/install-skills.mjs`, use a directory junction on Windows and the existing directory symlink elsewhere. Preserve all flags, ownership detection, force behavior, and uninstall behavior; add tests for both strategies.
-- Add `.gitattributes` at minimum for `*.sh text eol=lf` and `*.ps1 text`, matching the already-shipped generated-script guidance.
-
-### 7. Support matrix and documentation
-
-Document the result in `README.md` and `DECISIONS.md` only after CI proves it:
-
-| Environment | Expected status after implementation |
+| Protected surface | Treatment |
 |---|---|
-| macOS/Linux POSIX | Fully supported; no behavior regression. |
-| WSL2 | Fully supported through POSIX family. |
-| Windows + Git Bash/MSYS | Fully supported through POSIX family; LF policy enforced. |
-| Native Windows + PowerShell 7 | Fully supported for setup, PR pipeline, review, QA orchestration, and local repository gate. |
-| Native Windows + Windows PowerShell 5.1 only | Limited compatibility for explicitly documented legacy flows; full pipeline preflight requests PowerShell 7. |
+| Skill names/layout | Unchanged. |
+| Config version | Remains 1; `validation.steps` is optional and preferred over legacy `commands`. |
+| Tracker operations/guards | Names, inputs, outputs, and postconditions unchanged; implementation representation becomes shell-neutral. |
+| `test-env.json` | Optional additive `launch`; existing entrypoint fields remain readable. |
+| Progress/chaining/markers | Byte-compatible where parsed. |
+| Lint entrypoint | `bash scripts/lint.sh` remains a wrapper. |
+| Installer CLI | Flags/output preserved; Windows link primitive changes internally. |
 
-Do not use “works on Windows” without naming the tested shell and prerequisites.
+No implementation may use evaluated strings, broaden cleanup targets, mutate machine execution policy, install a shell, or treat a missing prerequisite as success.
 
-## Contract and Compatibility Review
+## Failure and edge cases
 
-| Protected surface | Change | Compatibility treatment |
-|---|---|---|
-| Skill names/layout | None | No renames, aliases, or directory moves. |
-| Config schema | Add optional `validation.commandsByShell` | Version remains 1; legacy `commands` stays the fallback and is never removed. |
-| Tracker operations/guards | Add execution-family recipes and capability marker | Names, inputs, outputs, and semantics remain identical; template and shipped/repo descriptors update together. |
-| Browser operations | No semantic change | Existing Windows implementation is retained and reused as precedent. |
-| Cross-skill files | No format change | Progress, tracking-plan lines, chaining references, and `test-env.json` remain unchanged. |
-| Label taxonomy | None | No label additions, removals, or semantic changes. |
-| Installer CLI | Internal Windows link strategy change | Existing scripts/flags/output remain; ownership detection accepts junctions created by this repository. |
-| Lint CLI | Add Node implementation | `scripts/lint.sh` remains as a wrapper for existing callers. |
-
-No migration may require consumer repositories to regenerate `.ai/agentic.config.json`. Descriptor upgrades are needed only to enable native PowerShell mutations; POSIX use of older descriptors remains unchanged.
-
-## Edge Cases and Failure Scenarios
-
-| Scenario | Required behavior |
+| Scenario | Required result |
 |---|---|
-| Repository path contains spaces or Unicode | All setup, worktree, body-file, and validation operations succeed; no string-built command line is evaluated. |
-| Windows drive or UNC path | Resolve with platform APIs; never concatenate a POSIX root or assume `C:` is part of a shell token. If Git worktrees do not support the resolved target, stop before mutation with the exact path and Git error. |
-| Only Windows PowerShell 5.1 is installed | Full-pipeline preflight stops with a PowerShell 7 prerequisite; already-supported 5.1 flows keep their explicit encoding/execution-policy fallback. |
-| `gh` or tracker CLI missing | The descriptor's auth/prerequisite check fails before claims or partial label mutations. |
-| Old repo-local tracker descriptor on PowerShell | Execute only shell-neutral reads that are unambiguous; stop before compound mutation and name the descriptor upgrade path. Never replace custom content silently. |
-| Only legacy `validation.commands` exists | Execute it in the active shell. On shell syntax failure, fail the gate and recommend adding `commandsByShell`; never report success based on a translated guess. |
-| PowerShell native command returns non-zero without throwing | Recipe checks `$LASTEXITCODE` and fails; `$ErrorActionPreference` alone is insufficient. |
-| Interrupted worktree run | `finally` removes only the worktree created by that run and prunes metadata; the user's primary checkout and pre-existing worktrees remain untouched. |
-| `core.autocrlf=true` | `.sh` files retain LF; PowerShell files remain readable; CI validates line endings. |
-| Windows symlink privilege unavailable | Development installer uses a junction and does not request elevation or Developer Mode. |
-| Shell families produce different text/JSON | Contract tests compare normalized semantic outputs, not cosmetic whitespace. Parsed markers remain byte-compatible where consumers require exact lines. |
+| Agent cannot invoke argv directly | Stop before mutation and name the missing executor capability. |
+| Missing Git/tracker/program | Stop before the affected operation; show program and args without secrets. |
+| Malformed `validation.steps` | Config error before validation; no fallback to `commands`. |
+| Only legacy command strings on Windows | Use them only with an explicitly available compatible runner; otherwise request structured steps. |
+| Spaces, Unicode, drive/UNC paths | Pass as single arguments; never quote-and-evaluate. |
+| Native process returns non-zero | Fail the step and execute only owned cleanup/handback. |
+| Interrupted worktree/tracker run | Remove only run-owned temporary/worktree state and preserve primary checkout/external state. |
+| Old customized tracker descriptor | Preserve it; clean stop before unsupported compound mutation. |
+| Structured launch absent | Use compatible legacy entrypoint or report the exact migration needed. |
 
-## Security and Safety Review
+## Specification set and exclusive ownership
 
-- Do not loosen the untrusted-content boundary while adding platform recipes.
-- Never use `Invoke-Expression`, `cmd /c` string construction, or PowerShell's stop-parsing token as a general quoting workaround. Pass arguments as arrays/native argv.
-- Do not change machine-wide execution policy, enable Developer Mode, request elevation, or install WSL/Git Bash automatically.
-- Preserve the exact destructive-action scope of cleanup. PowerShell `Remove-Item -Recurse -Force` is allowed only for an explicitly resolved, run-owned temporary/worktree path after validation; broad roots and unresolved variables remain forbidden.
-- Tracker body and evidence operations continue using files/stdin to prevent interpolation and secret leakage.
+1. [Cross-platform validation gate](2026-08-25-windows-cross-platform-validation-gate.md): Node lint, portability lint, line endings, required CI.
+2. [Shell-neutral config/setup foundation](2026-08-25-native-windows-execution-foundation.md): operation model, structured validation schema, and 36 setup copies.
+3. [Shell-neutral worktree lifecycle](2026-08-25-shell-neutral-worktree-lifecycle.md): nine worktree copies.
+4. [Shell-neutral tracker operations](2026-08-25-shell-neutral-tracker-operations.md): tracker descriptors and guards.
+5. [Shell-neutral author/open/fix workflows](2026-08-25-native-windows-core-pr-workflows.md): six coupled author/fix routes.
+6. [Shell-neutral continue workflow](2026-08-25-shell-neutral-continue-workflow.md): `om-auto-continue-pr`.
+7. [Shell-neutral review workflows](2026-08-25-shell-neutral-review-workflows.md): code review, autonomous review, and autopilot.
+8. [Shell-neutral loop workflows](2026-08-25-native-windows-loop-workflows.md): create/continue loop helpers.
+9. [Shell-neutral QA bootstrap](2026-08-25-native-windows-qa-bootstrap.md): structured launch producers/consumers.
+10. [Shell-neutral changelog window](2026-08-25-native-windows-changelog-window.md): release-window selection.
+11. [Shell-neutral skill-authoring gates](2026-08-25-native-windows-skill-authoring-gates.md): authoring checks.
+12. [Shell-neutral upgrade-notes application](2026-08-25-native-windows-repo-maintenance.md): descriptor upgrade application.
+13. [Shell-neutral check and commit](2026-08-25-shell-neutral-check-and-commit.md): validation and local commit.
+14. [Windows skill installer](2026-08-25-windows-skill-installer.md): directory junctions.
+15. [Cross-platform security audit](2026-08-25-windows-security-audit-tooling.md): Node informational audit.
+16. [Cross-platform native E2E harness](2026-08-25-windows-native-e2e-harness.md): shell-free structured launch/provider evidence.
+17. [Compatibility support publication](2026-08-25-windows-support-publication.md): README claims after all evidence passes.
 
-## Validation Strategy
+Each child owns exactly the files named in its Scope. Config/setup owns config-related protected-contract sections; tracker owns tracker sections; QA owns `test-env.json` sections. `README.md` belongs only to publication.
 
-### Static gates
+### Mandatory standard-file authorization
 
-- Existing frontmatter, product-agnosticism, reference resolution, roster, and tracker-abstraction assertions run through `node scripts/lint.mjs` on Ubuntu and Windows.
-- A portability check inventories executable Markdown fences and rejects any new compound Bash block that lacks a classification or PowerShell pair.
-- Parse every committed/generated `.ps1` fixture with PowerShell's parser; parse POSIX scripts with the current shell gate.
-- Verify `.gitattributes` line-ending policy.
+Before config/setup edits shared setup text, it must ask to synchronize these 36 owners:
 
-### Windows execution matrix
+- `om-apply-upgrade-notes`, `om-approve-merge-pr`, `om-auto-continue-pr`, `om-auto-continue-pr-loop`, `om-auto-create-pr`, `om-auto-create-pr-loop`
+- `om-auto-fix-issue`, `om-auto-fix-pr`, `om-auto-implement-spec`, `om-auto-manage-issues`, `om-auto-qa-pr`, `om-auto-review-pr`
+- `om-auto-update-changelog`, `om-auto-write-spec`, `om-brainstorm`, `om-check-and-commit`, `om-close-fixed-issues`, `om-code-review`
+- `om-create-skill`, `om-fix`, `om-followup-issue-from-pr`, `om-integration-tests`, `om-merge-buddy`, `om-open-pr`
+- `om-pipeline-retro`, `om-pr-autopilot`, `om-prepare-issue`, `om-prepare-test-env`, `om-review-prs`, `om-root-cause`
+- `om-setup-agent-pipeline`, `om-spec-writing`, `om-ux-review-pr`, `om-ux-setup`, `om-ux-shape`, `om-verify-in-repo`
 
-Add a `windows-latest` CI job whose `run` steps use `shell: pwsh` and never invoke Bash:
+The worktree spec separately asks to synchronize nine owners: `om-auto-continue-pr-loop`, `om-auto-continue-pr`, `om-auto-create-pr-loop`, `om-auto-create-pr`, `om-auto-fix-issue`, `om-auto-fix-pr`, `om-auto-qa-pr`, `om-auto-review-pr`, and `om-auto-write-spec`. Without explicit authorization, stop before edits.
 
-1. Load minimal, full, and legacy `.ai/agentic.config.json` fixtures; resolve defaults and `commandsByShell` correctly.
-2. Create and clean an isolated Git worktree in a path containing spaces; assert the primary worktree is unchanged.
-3. Exercise GitHub descriptor guard functions against a mock `gh` executable/function: missing label degrades, disabled labels no-op, pipeline labels remain exclusive, multiline bodies preserve formatting, and non-zero exits fail.
-4. Verify run-folder and temporary-file helpers with native temp paths.
-5. Run the Node lint and browser-provider platform matrix.
-6. Install and uninstall fixture skills through Windows junctions without elevation.
-7. Execute a PowerShell test-environment/provider fixture and assert no `sh`, WSL, Git Bash, `jq`, or POSIX utility is launched.
+## Validation strategy
 
-### Regression matrix
+- Contract fixtures provide an in-memory agent-capability adapter and mock executables; assert exact program/args/cwd/env, exit handling, postconditions, and cleanup.
+- Real Git worktree tests run in paths with spaces and Unicode on Ubuntu and Windows.
+- Mock `gh` exercises every named tracker route, including claims, label guards/exclusivity, body files, handback, failures, and cleanup.
+- Every promised workflow route gets its own end-to-end fixture; generic smoke coverage is insufficient.
+- Portability lint rejects new orchestration that depends on shell syntax or unclassified opaque command strings.
+- Required CI runs authoritative Node repository gates on Ubuntu and Windows. Bash wrapper compatibility is tested only on Ubuntu.
 
-- Keep an Ubuntu POSIX job running the compatibility wrapper `bash scripts/lint.sh` and representative POSIX recipes.
-- Add a Windows Git Bash lane only for the LF/Git-Bash support claim; it is not evidence for native PowerShell.
-- Require both native Windows and POSIX jobs before the support claim is published.
+## Complete migration inventory
 
-## Risks & Impact Review
+- Config/setup: all 36 setup copies; setup `SKILL.md`, interview/project-docs/coverage references; config/process documents and config compatibility section.
+- Worktree: all nine standard copies. Tracker: template, shipped/repo GitHub descriptors, and tracker compatibility section.
+- Author/fix: non-standard files for create, fix-issue, fix-PR, interactive fix, open-PR, and verify-in-repo. Continue owns its one route. Review owns code-review, auto-review, autopilot, label/CI transitions, and reports.
+- Loops: the four command-heavy references in each create/continue loop skill.
+- Focused runtime: QA’s named launch producers/consumers; changelog `SKILL.md` and `release-window.md`; create-skill gates/repo-invariants/shared-boilerplate; upgrade-notes and check-and-commit each own their non-standard files.
+- Structured launch: QA owns its named prepare-test-env, integration-test, auto-QA, and protected-contract producer/consumer files. Prepare-test-env `build-cache.md`, reports/rules, and the agent-browser descriptor remain regression baselines unless a failing contract test first amends scope.
+- Tooling ownership: validation owns lint/package/line endings/lint workflow/classifier tests; installer owns install script/tests; audit owns audit script/workflow; E2E owns provider/pin/harness fixtures/workflows; publication owns README support text.
 
-- **Highest risk — duplicated standard files:** platform policy and worktree logic can drift across skills. Mitigation: synchronize all copies in one implementation PR, machine-check shared sections, and follow the repository's mandatory ask-before-sync rule.
-- **High risk — tracker parity:** a PowerShell guard that partially mutates labels or claims before failing could corrupt pipeline state. Mitigation: mock-driven operation tests and identical postconditions for both families.
-- **Medium risk — config precedence:** updated and old skills may choose different validation arrays. Mitigation: additive fallback order, documentation, and no removal of `commands` until a future versioned migration (not proposed here).
-- **Medium risk — documentation size:** naively pairing all 92 Bash blocks would inflate token cost. Mitigation: pair only compound shell logic, keep native argv commands single-sourced, and push detail into the existing per-skill references.
-- **Medium risk — PowerShell version behavior:** quoting and encoding differ between 5.1 and 7. Mitigation: one full-pipeline baseline (7), explicit limited 5.1 status, and CI on the baseline.
-- **Low risk — developer tooling migration:** moving lint logic to Node can change edge-case output. Mitigation: golden tests comparing current lint fixtures and retaining the Bash wrapper.
+## Roadmap completion criteria
 
-Rollback is phase-local: revert the relevant phase commits. Because config additions are optional and no existing format is rewritten, reverting leaves legacy POSIX consumers functional. Consumer repos that copied a newer descriptor retain an additive PowerShell section that older skills ignore.
-
-## Phasing
-
-### Phase 1: Platform contract and cross-platform gate
-
-Ship the execution-family policy, additive validation schema, Node lint implementation plus Bash wrapper, Windows junction installer behavior, `.gitattributes`, and initial Windows CI fixtures. This phase makes the repository's own portability requirements executable without claiming the full skill pipeline is ready.
-
-### Phase 2: Core PR pipeline on PowerShell
-
-Synchronize agentic setup and all nine worktree standard references; add PowerShell tracker descriptor implementations; migrate the core author/reviewer paths (`om-auto-create-pr`, continue, fix, review, open PR, setup). Prove an end-to-end fixture can plan, worktree, validate, and prepare tracker mutations natively.
-
-### Phase 3: Loop, QA, release, and authoring coverage
-
-Migrate command-heavy loop, QA bootstrap, changelog, create-skill, and coverage references; complete the 92-fence classification; add regression lint; publish the support matrix only when all lanes pass.
-
-Each phase is independently shippable and preserves the POSIX pipeline.
-
-## Implementation Plan
-
-### Phase 1: Platform contract and repository gate
-
-1. Document the `posix`/`powershell` execution-family contract and PowerShell 7 baseline in `AGENTS.md`, `DECISIONS.md`, and the setup skill's schema/reference material; add `validation.commandsByShell` with legacy fallback and update `.ai/agentic.config.json` plus `SDLC.md` together.
-2. Reimplement the lint gate in `scripts/lint.mjs`, retain `scripts/lint.sh` as a wrapper, switch package/config/CI callers to Node, and add golden lint fixtures.
-3. Make `scripts/install-skills.mjs` use Windows junctions with ownership-safe uninstall; add `.gitattributes` and cross-platform installer tests.
-4. Add the `windows-latest` PowerShell contract job and a portability-fence inventory that initially reports the Phase 2/3 backlog without blocking unchanged legacy files.
-
-### Phase 2: Core pipeline recipes
-
-1. Before editing standard references, enumerate every affected `agentic-setup.md` and `worktree-setup.md` owner and obtain the repository-required synchronization decision; record it in the implementation plan/PR.
-2. Synchronize platform selection and native config loading across all affected `agentic-setup.md` copies, preserving skill-specific sections.
-3. Add equivalent PowerShell worktree create/reuse/cleanup recipes to all nine standard `worktree-setup.md` copies and add path-with-spaces lifecycle tests.
-4. Add execution-family capability and PowerShell implementations to the tracker template, shipped GitHub descriptor, and repo descriptor; test guarded reads/mutations against a mock CLI.
-5. Update the setup, create/continue, fix, open-PR, and review workflows to select recipes mechanically and report the execution family; run a native Windows end-to-end fixture and the full POSIX regression gate.
-
-### Phase 3: Complete collection coverage
-
-1. Classify every executable Bash fence and migrate the loop/run-folder/step-review references for create/continue loop skills.
-2. Migrate QA bootstrap, review label transitions, changelog release-window, create-skill gates, setup coverage, and remaining command-heavy outliers.
-3. Port or explicitly scope informational developer scripts, add the native PowerShell provider/test-environment smoke path, and turn the portability inventory into a blocking lint rule for new regressions.
-4. Re-run all Windows and POSIX gates, verify protected contracts and standard-file synchronization, then update README support claims and release notes.
-
-## Completion Criteria
-
-- A native `windows-latest` PowerShell job completes setup/config loading, worktree lifecycle, tracker guard fixtures, validation selection, lint, installer, and provider smoke tests without invoking Bash, WSL, Git Bash, `jq`, or POSIX utilities.
-- Representative `om-auto-create-pr` and `om-auto-review-pr` fixture runs reach their expected tracker-operation boundary using only the PowerShell family and preserve exact Progress/chaining formats.
-- All nine worktree copies and all affected agentic-setup shared sections are synchronized, with the required user sync decision documented.
-- Updated and legacy configs both resolve validation commands correctly; older descriptors continue on POSIX and fail cleanly with an upgrade path on native PowerShell before mutation.
-- `bash scripts/lint.sh` remains green and behavior-compatible; `node scripts/lint.mjs` is the authoritative cross-platform gate.
-- README claims native Windows support only after required Windows CI is green.
-- No protected contract listed in `BACKWARD_COMPATIBILITY.md` is renamed, removed, or made mandatory without a fallback.
+- Installed skills require no Bash, PowerShell, Node, Python, `jq`, or POSIX utility for orchestration beyond executables explicitly required by the target operation.
+- No platform selector or duplicated OS-specific control-flow branch is introduced.
+- Structured validation and launch forms work identically on Ubuntu and Windows; legacy forms fail cleanly when their runner is absent.
+- Every tracker and workflow route passes route-specific success/failure/cleanup fixtures.
+- All standard copies are synchronized only after the required authorization.
+- README publishes only claims backed by required green CI.

--- a/.ai/specs/2026-08-25-windows-cross-platform-validation-gate.md
+++ b/.ai/specs/2026-08-25-windows-cross-platform-validation-gate.md
@@ -1,0 +1,44 @@
+# Windows Cross-Platform Validation Gate
+
+## TLDR
+
+Make this repository’s required lint gate one dependency-free Node program on every OS while retaining the protected Bash wrapper.
+
+## Scope
+
+Exclusively owns `scripts/lint.sh`, new `scripts/lint.mjs`, `package.json`, new `.gitattributes`, `.github/workflows/lint.yml`, `scripts/test-classify-runs.mjs`, and `scripts/test-close-keywords.mjs`. It validates, but does not edit, execution-foundation config/process files.
+
+## Non-goals
+
+Installer, security audit, provider E2E, runtime skill recipes, and support claims are separate specs.
+
+## Proposed solution
+
+- Move authoritative lint behavior to dependency-free Node; keep `bash scripts/lint.sh` as a thin compatibility wrapper with equivalent output/exit status.
+- Point package lint and required Ubuntu/Windows CI jobs directly to Node.
+- Add a portability inventory that rejects new shell-language orchestration and opaque command strings while allowing direct executable/argument examples and declared legacy wrappers.
+- Add `.gitattributes` with LF for shell files and text handling for PowerShell files.
+
+## Compatibility and failures
+
+Existing callers of `bash scripts/lint.sh` continue to work. Golden fixtures prevent diagnostic or coverage loss. Windows CI directly invokes `node scripts/lint.mjs`; workflow YAML shell plumbing is not part of skill orchestration evidence.
+
+## Validation
+
+Run positive/negative golden fixtures through old baseline and new Node logic, test line endings, run `node scripts/lint.mjs` on Ubuntu and Windows, and retain an Ubuntu wrapper job. Exercise both existing `.mjs` test tools on both OSes.
+
+## Implementation Plan
+
+1.1 Capture current lint fixture behavior and exit codes.
+
+1.2 Implement the Node gate and compatibility wrapper; migrate package invocation.
+
+2.1 Add portability classification and line-ending checks.
+
+2.2 Add required Ubuntu/Windows workflow lanes and prove the gate itself launches no shell process.
+
+## Completion Criteria
+
+- Node and wrapper gates have equivalent coverage and status.
+- Required Windows and Ubuntu jobs pass from clean checkouts.
+- New shell-language orchestration is rejected without creating any platform-specific duplicate.

--- a/.ai/specs/2026-08-25-windows-native-e2e-harness.md
+++ b/.ai/specs/2026-08-25-windows-native-e2e-harness.md
@@ -1,0 +1,35 @@
+# Cross-Platform Native E2E Harness
+
+## TLDR
+
+Replace the shell harness with one Node provider smoke harness and exercise structured launch on Ubuntu and Windows.
+
+## Scope
+
+Depends on the validation-gate and QA-bootstrap specs. Exclusively owns `scripts/test-agent-browser-codex.sh`, a new authoritative Node counterpart, `scripts/fixtures/agent-browser-codex/`, `scripts/test-browser-providers.mjs`, `scripts/bump-agent-browser.mjs`, `.github/workflows/agent-browser-pin.yml`, and new `.github/workflows/windows-e2e.yml`.
+
+## Non-goals
+
+Do not redesign provider descriptors, prepare-test-env contracts, QA bootstrap, or pinning policy. Those are dependencies/baselines.
+
+## Proposed solution
+
+Move authoritative harness behavior to dependency-free Node and keep the shell file only as a compatibility wrapper if its public entrypoint is protected. Exercise pinned asset mapping, structured launch, legacy entrypoint compatibility, readiness/cleanup, update checks, and fixture output. Assert the structured route starts no shell, WSL, `jq`, or Python process.
+
+## Failure scenarios
+
+Missing asset, checksum/version mismatch, malformed descriptor, early process exit, timeout, and cleanup failure each produce an explicit failed scenario with retained diagnostics and no orphan process.
+
+## Validation and plan
+
+1.1 Define normalized fixture outputs and process-observation assertions.
+
+1.2 Add the Node harness and run every success/failure route on Ubuntu and `windows-latest`.
+
+1.3 Run provider matrix and pin/update fixtures on Ubuntu and Windows; compare semantic outputs.
+
+## Completion Criteria
+
+- Every promised provider/test-environment route is exercised through one harness, including all listed failures.
+- Structured launch evidence contains no shell dependency and leaves no process/artifact behind.
+- Existing shell entrypoint remains behavior-compatible as a wrapper; provider contracts remain compatible.

--- a/.ai/specs/2026-08-25-windows-security-audit-tooling.md
+++ b/.ai/specs/2026-08-25-windows-security-audit-tooling.md
@@ -1,0 +1,31 @@
+# Windows Security-Audit Tooling
+
+## TLDR
+
+Make the collection’s informational skills audit cross-platform without changing its findings policy.
+
+## Scope
+
+Exclusively owns `scripts/audit-skills.sh`, new `scripts/audit-skills.mjs`, and `.github/workflows/skills-audit.yml`.
+
+## Proposed solution
+
+Move authoritative discovery, third-party audit invocation, and result normalization to Node. Keep the shell file as a compatibility wrapper if users call it directly. Run the informational workflow on Ubuntu and Windows with identical fixture expectations.
+
+## Compatibility and failures
+
+Preserve informational/non-blocking CI status, audited skill set, severity/result presentation, and exit conventions. Missing third-party tooling, network failure, and malformed output remain distinguishable; do not turn an unavailable audit into a pass.
+
+## Validation and plan
+
+1.1 Capture golden results for clean, finding, missing-tool, network-error, and malformed-output fixtures.
+
+1.2 Implement Node audit and optional wrapper parity.
+
+1.3 Add Windows/Ubuntu workflow lanes and compare normalized outputs.
+
+## Completion Criteria
+
+- Both OS lanes classify every fixture identically.
+- The job remains informational and does not weaken or silently skip findings.
+- Existing direct shell entrypoint remains compatible if retained.

--- a/.ai/specs/2026-08-25-windows-skill-installer.md
+++ b/.ai/specs/2026-08-25-windows-skill-installer.md
@@ -1,0 +1,31 @@
+# Windows Skill Installer
+
+## TLDR
+
+Install development skill links on Windows without elevation by using directory junctions.
+
+## Scope
+
+Exclusively owns `scripts/install-skills.mjs` and new installer fixtures/tests. Runtime skills and CI support claims are outside scope.
+
+## Proposed solution
+
+Use Node directory junctions on Windows and retain directory symlinks elsewhere. Resolve junction targets as absolute paths. Preserve CLI flags, selection, ownership detection, force semantics, messages, and uninstall behavior; never remove a link not owned by this installer.
+
+## Failure scenarios
+
+Existing correct link is idempotent; conflicting file/link reports or obeys existing force rules; missing target and denied destination fail without partial installation; uninstall removes the junction, never its target.
+
+## Validation and plan
+
+1.1 Extract/test link-strategy selection for Windows and non-Windows.
+
+1.2 Add temp-directory install, repeat, conflict, force, and uninstall fixtures with spaced Unicode paths.
+
+1.3 Run real junction lifecycle on `windows-latest` and real symlink lifecycle on Ubuntu/macOS where available.
+
+## Completion Criteria
+
+- Standard Windows install/uninstall works without Developer Mode or elevation.
+- All existing CLI and ownership behaviors remain compatible.
+- Tests prove targets survive uninstall and conflict cleanup.

--- a/.ai/specs/2026-08-25-windows-support-publication.md
+++ b/.ai/specs/2026-08-25-windows-support-publication.md
@@ -1,0 +1,31 @@
+# Windows Support Publication
+
+## TLDR
+
+Publish the compatibility matrix only after the single shell-neutral runtime and tooling implementations have supplied green evidence.
+
+## Dependencies and scope
+
+Depends on completion of the other sixteen roadmap specs and green required Ubuntu/Windows workflows. Exclusively owns `README.md` support-matrix and release-facing compatibility wording; it does not change runtime behavior, contracts, or CI.
+
+## Proposed solution
+
+Collect immutable workflow links and tested prerequisites, then document the same shell-neutral agent contract on macOS, Linux, and Windows. Name Git and tracker prerequisites; clarify that Node is required by this repository’s tools, not installed skills. Document legacy shell-entrypoint limitations separately rather than creating runtime support branches.
+
+## Failure behavior
+
+If any child spec is incomplete, a required lane is optional/failing, or native evidence invokes Bash, stop publication and list the missing evidence. Documentation cannot waive a failed route.
+
+## Validation and plan
+
+1.1 Build an evidence table mapping every support claim to required workflow/scenario results.
+
+1.2 Update README wording only after the table is complete and green.
+
+1.3 Check links, terminology, prerequisite boundaries, and consistency with `DECISIONS.md`, `SDLC.md`, and the roadmap; run repository lint.
+
+## Completion Criteria
+
+- Every published environment claim has current native evidence for every promised route.
+- Prerequisites and limited/unsupported shells are explicit.
+- Documentation makes no broader claim than CI proves.


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-25-windows-compatibility-spec.md
Source doc: .ai/specs/2026-08-25-windows-compatibility.md
Status: complete

## 🎯 Goal
- Audit Windows blockers and specify one shell-neutral execution model instead of maintaining Bash and PowerShell branches.

## What Changed
- Added the compatibility audit and structured file/process/validation/launch contracts.
- Split implementation into 17 dependency-ordered, independently shippable specifications with exclusive ownership.
- Preserved legacy config, tracker, test-env, chaining, and lint entrypoints additively.

## 🧪 Tests
- `bash scripts/lint.sh`
- `git diff --check origin/main...HEAD`
- Fresh-context scope-cohesion review, findings incorporated.

## 💥 Breaking Changes
- None; this is a spec-only design PR.

## 📋 Progress
See the completed Progress section in the tracking plan.
