### PR TITLE
docs(om-auto-fix-pr): drop the stale --max-iterations default from stabilize-ci

### DIFF
--- a/skills/om-auto-fix-pr/references/stabilize-ci.md
+++ b/skills/om-auto-fix-pr/references/stabilize-ci.md
@@ -28,7 +28,9 @@ merge.
 2. **Stabilize CI — the CI procedure below.** Pull check status through the
    tracker, classify each failure (real bug / test bug / flake / infra), fix the
    real ones with tests, push, re-check. Never go green by weakening a test or
-   disabling a check. Honor `--max-iterations` for the inner fix→push→re-check loop.
+   disabling a check. Honor `--max-iterations` for the inner fix→push→re-check loop —
+   the same flag that bounds the outer loop, defined once with its default in
+   `SKILL.md` (Arguments); never restate a default here, where it can drift.
 3. **Verify UI — `om-auto-qa-pr {prNumber}`** — only when the diff touches a
    user-facing surface (inspect **get-pr-diff** / **get-pr-files** for UI paths)
    and `--no-ui` was not passed. It boots the app, drives the changed flow, and
@@ -58,7 +60,7 @@ Classify every check as passing, pending, or failing. Nothing failing and nothin
 pending → report "already green". Checks pending → **watch-run** (or poll) until they
 settle before diagnosing, under the wait budget below.
 
-### The fix → push → re-check loop (up to `--max-iterations`, default 5)
+### The fix → push → re-check loop (up to `--max-iterations`)
 
 Per iteration:
 


### PR DESCRIPTION
## 🎯 Goal

`om-auto-fix-pr` documents `--max-iterations` twice, with two different defaults. Leave one.

## The inconsistency

- `skills/om-auto-fix-pr/SKILL.md:33` — *"`--max-iterations <n>` (optional) — outer review→CI→UI cycles before stopping with a report (**also caps the inner CI fix→push→re-check loop**). Default: `3`"*
- `skills/om-auto-fix-pr/references/stabilize-ci.md:61` — *"### The fix → push → re-check loop (up to `--max-iterations`, **default 5**)"*

Same flag, and `SKILL.md` says explicitly that it bounds both loops — so an agent reading the reference file budgets five inner cycles where the flag gives it three.

## Why 5 is the stale one

It is a fossil, not a deliberate second default. `--max-iterations` with `Default: 5` belonged to the standalone `om-stabilize-ci` skill (`git show 3817c0b^:skills/om-stabilize-ci/SKILL.md:13` — *"fix→push→re-check cycles before stopping with a report. Default: 5."*). Commit 3817c0b absorbed that skill into `om-auto-fix-pr`, where the flag became the **outer** loop's with default 3; the heading came across carrying its old skill's number.

## What changed

The heading drops the parenthetical entirely rather than correcting `5` to `3`, so the flag keeps exactly one definition and cannot drift a second time. The one place in the file that tells the reader the inner loop honors the flag now points at that definition and says not to restate it. `om-pr-autopilot/SKILL.md:31`, which forwards the flag, already documents `Default 3` and is untouched.

## 💥 Breaking changes

None — no behavior, contract surface, operation, or config key is involved. The change is one heading and one clause in a `references/` file.

## 🧪 Tests

The full `lint.yml` gate, locally, in order:

- `bash scripts/lint.sh` — pass (`Lint OK`)
- `node scripts/test-browser-providers.mjs` — pass
- `node scripts/test-classify-runs.mjs` — pass
- `node scripts/test-close-keywords.mjs` — pass

Found alongside #89, which touches the same file's baseline section; the two do not overlap in content and should merge in either order (a trivial context rebase at worst).
