### PR TITLE
feat(om-fix): intention-learning differential regression gate

### DIFF
--- a/.ai/runs/2026-08-28-om-fix-intention-differential-gate.md
+++ b/.ai/runs/2026-08-28-om-fix-intention-differential-gate.md
@@ -1,0 +1,42 @@
+# Execution plan: om-fix intention-learning differential regression gate
+
+Source doc: .ai/specs/2026-08-28-om-fix-intention-differential-gate.md (from PR #93, not yet merged to main)
+
+## 🎯 Goal
+Reorder `om-fix`'s workflow into a test-first Intention-Learning + Red/Green differential regression gate, so a regression test is proven to fail on the unmodified (buggy) code before the fix is applied and proven to pass after, closing the "misguidance effect" where a test written against already-patched code cements the bug into its own assertions.
+
+## Scope
+- `skills/om-fix/SKILL.md` — reorder Steps 2–5 per the spec's table.
+- `skills/om-fix/references/regression-gate.md` — new file: Intention-Learning discipline, test-first Red/Green protocol, flaky-test/can't-reproduce failure paths, judgment-bounded `Status: blocked` escape hatch.
+- `UPGRADE_NOTES.md` — new entry documenting the behavior change.
+
+## Non-goals
+- SBST/CodaMosa coverage expansion — covered by the sibling spec `.ai/specs/2026-08-28-om-fix-sbst-coverage-expansion.md`, implemented in a separate follow-up run.
+- Any change to `om-setup-agent-pipeline`.
+- Any change to the `om-fix` output contract's shape (Status/Files changed/Summary/Tests/Breaking changes lines stay the same; only the `Tests:` line's content gains a note).
+
+## Risks
+- `skills/om-fix/SKILL.md` step reordering could break something that cross-references a specific step number — verified during spec review that no other installed skill references `om-fix`'s internal step numbers.
+- `scripts/lint.sh`'s body-length budget (~20,000 chars) and product-agnostic grep gate apply to `SKILL.md` — mechanics are kept in the new reference file to stay well under budget.
+
+## Implementation Plan
+
+### Phase 1: Differential regression gate
+
+- 1.1 Write `skills/om-fix/references/regression-gate.md`
+- 1.2 Reorder `skills/om-fix/SKILL.md` Steps 2–5 into the Intention-Learning + Red/Green gate
+- 1.3 Re-read the full `SKILL.md` end to end for numbering/prose consistency
+- 1.4 Add an `UPGRADE_NOTES.md` entry for the behavior change
+- 1.5 Full validation gate (`bash scripts/lint.sh`)
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Differential regression gate
+
+- [ ] 1.1 Write `skills/om-fix/references/regression-gate.md`
+- [ ] 1.2 Reorder `skills/om-fix/SKILL.md` Steps 2–5 into the Intention-Learning + Red/Green gate
+- [ ] 1.3 Re-read the full `SKILL.md` end to end for numbering/prose consistency
+- [ ] 1.4 Add an `UPGRADE_NOTES.md` entry for the behavior change
+- [ ] 1.5 Full validation gate (`bash scripts/lint.sh`)

--- a/.ai/runs/2026-08-28-om-fix-intention-differential-gate.md
+++ b/.ai/runs/2026-08-28-om-fix-intention-differential-gate.md
@@ -35,8 +35,8 @@ Reorder `om-fix`'s workflow into a test-first Intention-Learning + Red/Green dif
 
 ### Phase 1: Differential regression gate
 
-- [ ] 1.1 Write `skills/om-fix/references/regression-gate.md`
-- [ ] 1.2 Reorder `skills/om-fix/SKILL.md` Steps 2–5 into the Intention-Learning + Red/Green gate
-- [ ] 1.3 Re-read the full `SKILL.md` end to end for numbering/prose consistency
+- [x] 1.1 Write `skills/om-fix/references/regression-gate.md` — 3de39f2
+- [x] 1.2 Reorder `skills/om-fix/SKILL.md` Steps 2–5 into the Intention-Learning + Red/Green gate — d4d9f5b
+- [x] 1.3 Re-read the full `SKILL.md` end to end for numbering/prose consistency — d4d9f5b (no separate diff; verified as part of the step 1.2 edit — no dangling step-number references, output contract unchanged except the `Tests:` line)
 - [ ] 1.4 Add an `UPGRADE_NOTES.md` entry for the behavior change
 - [ ] 1.5 Full validation gate (`bash scripts/lint.sh`)

--- a/.ai/runs/2026-08-28-om-fix-intention-differential-gate.md
+++ b/.ai/runs/2026-08-28-om-fix-intention-differential-gate.md
@@ -38,5 +38,5 @@ Reorder `om-fix`'s workflow into a test-first Intention-Learning + Red/Green dif
 - [x] 1.1 Write `skills/om-fix/references/regression-gate.md` — 3de39f2
 - [x] 1.2 Reorder `skills/om-fix/SKILL.md` Steps 2–5 into the Intention-Learning + Red/Green gate — d4d9f5b
 - [x] 1.3 Re-read the full `SKILL.md` end to end for numbering/prose consistency — d4d9f5b (no separate diff; verified as part of the step 1.2 edit — no dangling step-number references, output contract unchanged except the `Tests:` line)
-- [ ] 1.4 Add an `UPGRADE_NOTES.md` entry for the behavior change
-- [ ] 1.5 Full validation gate (`bash scripts/lint.sh`)
+- [x] 1.4 Add an `UPGRADE_NOTES.md` entry for the behavior change — 6b1e0ba
+- [x] 1.5 Full validation gate (`bash scripts/lint.sh`) — PASS (Lint OK.)

--- a/.ai/runs/2026-08-28-om-fix-intention-differential-gate.md
+++ b/.ai/runs/2026-08-28-om-fix-intention-differential-gate.md
@@ -40,3 +40,4 @@ Reorder `om-fix`'s workflow into a test-first Intention-Learning + Red/Green dif
 - [x] 1.3 Re-read the full `SKILL.md` end to end for numbering/prose consistency — d4d9f5b (no separate diff; verified as part of the step 1.2 edit — no dangling step-number references, output contract unchanged except the `Tests:` line)
 - [x] 1.4 Add an `UPGRADE_NOTES.md` entry for the behavior change — 6b1e0ba
 - [x] 1.5 Full validation gate (`bash scripts/lint.sh`) — PASS (Lint OK.)
+- [x] 1.6-review-fix Apply `om-auto-review-pr` findings: drop stale "and the regression test to add" from Step 2 (test is now authored in Step 3 from the Semantic Oracle, not identified in Step 2), retitle Step 2 to imperative style — pending commit

--- a/.ai/runs/2026-08-28-om-fix-intention-differential-gate.md
+++ b/.ai/runs/2026-08-28-om-fix-intention-differential-gate.md
@@ -31,6 +31,8 @@ Reorder `om-fix`'s workflow into a test-first Intention-Learning + Red/Green dif
 
 ## Progress
 
+PR: #94
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Differential regression gate

--- a/.ai/runs/2026-08-28-om-fix-intention-differential-gate.md
+++ b/.ai/runs/2026-08-28-om-fix-intention-differential-gate.md
@@ -40,4 +40,4 @@ Reorder `om-fix`'s workflow into a test-first Intention-Learning + Red/Green dif
 - [x] 1.3 Re-read the full `SKILL.md` end to end for numbering/prose consistency — d4d9f5b (no separate diff; verified as part of the step 1.2 edit — no dangling step-number references, output contract unchanged except the `Tests:` line)
 - [x] 1.4 Add an `UPGRADE_NOTES.md` entry for the behavior change — 6b1e0ba
 - [x] 1.5 Full validation gate (`bash scripts/lint.sh`) — PASS (Lint OK.)
-- [x] 1.6-review-fix Apply `om-auto-review-pr` findings: drop stale "and the regression test to add" from Step 2 (test is now authored in Step 3 from the Semantic Oracle, not identified in Step 2), retitle Step 2 to imperative style — pending commit
+- [x] 1.6-review-fix Apply `om-auto-review-pr` findings: drop stale "and the regression test to add" from Step 2 (test is now authored in Step 3 from the Semantic Oracle, not identified in Step 2), retitle Step 2 to imperative style — 61e48d2

--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -14,6 +14,14 @@ against them — not against the copies shipped in this repo:
 | `SDLC.md`, `CODE_REVIEW.md`, `BACKWARD_COMPATIBILITY.md`, `AGENTS.md` starter | `om-setup-agent-pipeline` | Regenerated only when missing — edit or regenerate deliberately |
 | `.ai/skills/<name>/SKILL.md` repo-local overrides | you | Never touched by upgrades; review them against new skill behavior |
 
+## 2026-08-28 — `om-fix` gains a test-first differential regression gate
+
+`om-fix` used to add its regression test *after* the fix, using the same context that produced the fix — exactly the setup where an LLM tends to assert what the code *does* rather than what it *should* do (the "misguidance effect"). Nothing verified the test would actually have caught the original bug.
+
+- **The workflow is reordered.** Step 2 now also performs Intention Learning — deriving the expected behavior from the issue/root-cause text alone, before treating the current code as ground truth. Step 3 drafts the regression test from that intent and runs it against the *unmodified* code, where it **must fail**; only once that's proven does step 4 make the fix, and step 5 reruns the same test to confirm it now **passes**. Mechanics: `skills/om-fix/references/regression-gate.md`.
+- **No new git commands, no new config.** The differential check is just "run the test before the fix, then again after" — no stashing or checkout tricks. This is purely a behavior change to an already-installed skill.
+- **Nothing to migrate.** The output contract (`Status:`/`Files changed:`/`Summary:`/`Tests:`/`Breaking changes:`) is unchanged in shape; the `Tests:` line now additionally notes the fail-then-pass verification. `om-fix` runs take one extra validation cycle per fix, and may occasionally end `Status: blocked` in a case that previously would have (weakly) proceeded with a test that was never verified against the bug — that is the intended, stricter behavior.
+
 ## 2026-08-13 — test-env credentials become references: new `credentialsFile` + `passwordEnv`
 
 The environment descriptor recorded demo login values inline (`"password": "<demo>"`), and the QA/test skills read them into the agent's context to sign in — so even demo-grade secrets flowed through model output into commands, and anything that ended up in the descriptor was one quote away from a report. Security audits flagged exactly this path on `om-integration-tests`.

--- a/skills/om-fix/SKILL.md
+++ b/skills/om-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: om-fix
-description: Implements the minimal code change identified by the om-root-cause step, adds regression tests, and runs the configured validation gate. Claims the tracker issue at start (assignee + in-progress label + claim comment) so concurrent automation backs off. Does not commit, push, or open a PR — that is the om-open-pr step's job.
+description: Implements the minimal code change identified by the om-root-cause step, proving the regression test fails without it and passes with it, then runs the configured validation gate. Claims the tracker issue at start (assignee + in-progress label + claim comment) so concurrent automation backs off. Does not commit, push, or open a PR — that is the om-open-pr step's job.
 ---
 
 # Apply Fix
@@ -35,7 +35,7 @@ Do not run `git commit`, `git push`, or the **create-pr** tracker operation — 
 
    Claim failures are non-fatal — log and continue. Do not release the lock here: `om-open-pr` releases it on success, an external janitor on failure. Full claim protocol (idempotency, stale locks, release ownership): `references/claim-pr.md`.
 
-2. **Read the analyzer's brief.** The analyzer's full output is included in your prompt, in a block marked:
+2. **Read the analyzer's brief & Intention Learning.** The analyzer's full output is included in your prompt, in a block marked:
 
    ```
    — PREVIOUS STEP (om-root-cause) said —
@@ -44,19 +44,26 @@ Do not run `git commit`, `git push`, or the **create-pr** tracker operation — 
 
    Identify from that block: the file(s) to change, the approach, and the regression test to add. **Do not invent your own root cause.** If the brief is missing, empty, or contradicts the repo (e.g. names files that don't exist), end your own output with `Status: blocked` and a one-line reason — the chain stops cleanly. If the analyzer ended with `LOW_CONFIDENCE`, be extra careful — re-read the affected code yourself before editing.
 
-3. **Make the minimal change.** Edit only the files the analyzer named (plus the test file). Do not refactor unrelated code. Do not broaden scope. Project-convention rules (apply to every fix):
+   Before writing any test or edit, form the **Semantic Oracle**: a plain statement of the code's *intended* behavior, grounded only in the issue description and this brief — never in what the current (buggy) code happens to return. Full discipline: `references/regression-gate.md`.
+
+3. **Draft the "Red" regression test — verify it fails.** Every fix MUST include test coverage — never skip tests, never ask whether to add them. Write the test from the Semantic Oracle, before touching production code, then run it now against the unmodified code:
+
+   - Add or update a unit test that must **fail** on the current, unfixed code — if it passes, it isn't exercising the bug; discard and rewrite it. Add integration tests when the change touches risky flows (permission checks, data scoping, behavior that crosses component boundaries).
+   - Tests must be self-contained and target the smallest meaningful scope.
+   - A flaky "fail" (inconsistent across repeated runs with no code change) counts as unreliable, not verified — rewrite it.
+   - No fixed retry limit — use judgment. If the test genuinely cannot be made to fail on the described bug after real effort, end with `Status: blocked` and a one-line reason instead of looping forever.
+
+   Full protocol (including the can't-reproduce and flaky-test handling): `references/regression-gate.md`.
+
+4. **Make the minimal change.** Edit only the files the analyzer named (plus the test file). Do not refactor unrelated code. Do not broaden scope. Project-convention rules (apply to every fix):
 
    - Follow the project's data-access conventions in production code — when the surrounding code routes through a helper or wrapper, use it; do not bypass it.
    - Preserve public contracts unless the issue explicitly requires a contract change: exported APIs, HTTP routes and response shapes, event names, CLI flags, DB schema, config formats. If the project documents its own compatibility rules, honor them.
    - Respect the project's data-scoping and permission-check rules.
 
-4. **Add regression tests (mandatory, autonomous).** Every fix MUST include test coverage — never skip tests, never ask whether to add them.
+5. **Verify Green, then the validation loop.** Rerun the exact test from step 3, unmodified, against the fixed code — it **must pass**. A failure here means the fix is incomplete, not the test; iterate on the fix and rerun, never rewrite the assertions to make it pass.
 
-   - Add or update a unit test that fails without your fix and passes with it
-   - Add integration tests when the change touches risky flows (permission checks, data scoping, behavior that crosses component boundaries)
-   - Tests must be self-contained and target the smallest meaningful scope
-
-5. **Validation loop.** Iterate until clean. Per iteration:
+   Once green, iterate the full validation loop until clean. Per iteration:
 
    1. Run targeted unit tests for every changed package/area
    2. Run the typecheck/lint commands from `validation.commands`, scoped to what changed when the toolchain supports scoping
@@ -76,7 +83,7 @@ Do not run `git commit`, `git push`, or the **create-pr** tracker operation — 
 
    Summary: <one paragraph — what changed and why it fixes the issue>
 
-   Tests: <which tests/checks were added and that the full validation gate passed (or which commands were skipped and why)>
+   Tests: <which tests/checks were added, confirmation the regression test was verified to fail on the unmodified code and pass on the fixed code, and that the full validation gate passed (or which commands were skipped and why)>
 
    Breaking changes: <"none" OR a short statement of the contract change and the migration/deprecation path>
    ```
@@ -86,7 +93,7 @@ Do not run `git commit`, `git push`, or the **create-pr** tracker operation — 
 ## Rules
 
 - Shared rules: `references/rules.md` — autonomous-run contract, label discipline, claim etiquette, secrets, markers, emoji glossary. They always apply.
-- Tests are mandatory and added autonomously — never hand off without them.
+- Tests are mandatory and added autonomously — never hand off without them. They are also proven, not assumed: the regression test in step 3 must fail on the unmodified code before step 4 touches anything — see `references/regression-gate.md`.
 - No commit, no push, no PR — leave that to `om-open-pr`.
 - Stay inside the worktree the engine prepared; do not create nested worktrees.
 - Keep scope minimal; refactors belong in their own PR.

--- a/skills/om-fix/SKILL.md
+++ b/skills/om-fix/SKILL.md
@@ -35,14 +35,14 @@ Do not run `git commit`, `git push`, or the **create-pr** tracker operation — 
 
    Claim failures are non-fatal — log and continue. Do not release the lock here: `om-open-pr` releases it on success, an external janitor on failure. Full claim protocol (idempotency, stale locks, release ownership): `references/claim-pr.md`.
 
-2. **Read the analyzer's brief & Intention Learning.** The analyzer's full output is included in your prompt, in a block marked:
+2. **Read the analyzer's brief and learn the intended behavior.** The analyzer's full output is included in your prompt, in a block marked:
 
    ```
    — PREVIOUS STEP (om-root-cause) said —
    <analyzer brief here>
    ```
 
-   Identify from that block: the file(s) to change, the approach, and the regression test to add. **Do not invent your own root cause.** If the brief is missing, empty, or contradicts the repo (e.g. names files that don't exist), end your own output with `Status: blocked` and a one-line reason — the chain stops cleanly. If the analyzer ended with `LOW_CONFIDENCE`, be extra careful — re-read the affected code yourself before editing.
+   Identify from that block: the file(s) to change and the approach. **Do not invent your own root cause.** If the brief is missing, empty, or contradicts the repo (e.g. names files that don't exist), end your own output with `Status: blocked` and a one-line reason — the chain stops cleanly. If the analyzer ended with `LOW_CONFIDENCE`, be extra careful — re-read the affected code yourself before editing.
 
    Before writing any test or edit, form the **Semantic Oracle**: a plain statement of the code's *intended* behavior, grounded only in the issue description and this brief — never in what the current (buggy) code happens to return. Full discipline: `references/regression-gate.md`.
 

--- a/skills/om-fix/references/regression-gate.md
+++ b/skills/om-fix/references/regression-gate.md
@@ -1,0 +1,38 @@
+# Intention-learning & differential regression gate (steps 2–5)
+
+Mechanics for the test-first Red/Green protocol referenced from the skill body. The point of reordering the workflow this way is narrow: a regression test that is only ever run *after* the fix cannot prove it would have caught the original bug — it has nothing to fail against. Writing and running it first gives that proof for free, with no extra machinery (no stashing, no throwaway branches) because at that point in the workflow no production edit exists yet.
+
+## Intention Learning (step 2)
+
+Before treating anything in the current code as correct, write down — in your own head or in the analysis you carry into the next step — what the code is *supposed* to do, using only:
+
+- the issue/bug description as told to you,
+- the analyzer's (`om-root-cause`) description of the bug and the intended fix.
+
+This is the **Semantic Oracle**: a plain statement of expected behavior derived from intent, not from output. The failure mode this guards against is subtle — an LLM asked to write a test against code it has just read as "the implementation" tends to assert what that code *does*, including its bug, rather than what it *should* do (the "misguidance effect"). Reading the buggy code to locate it is unavoidable and fine; the discipline is in *what grounds the assertion* — the issue text and root-cause brief, never "here's what the function currently returns."
+
+If the analyzer's brief already includes a proposed test snippet, treat it as a first draft input to this step, not as the oracle itself — still restate the expected behavior from the issue text and still put the snippet through the fail-first verification below before trusting it.
+
+## Draft the Red test, verify it fails (step 3)
+
+1. Write the regression test from the Semantic Oracle. Do not touch production code yet.
+2. Run the test now, against the unmodified code. It **must fail**.
+3. If it passes: it is not exercising the bug. Discard it and rewrite — either the assertion is too loose, or it accidentally tests a code path the bug doesn't reach. Repeat until the test genuinely fails on the unmodified code.
+4. If the test's outcome is not consistent across repeated runs (fails sometimes, passes other times, with no code change in between): treat it as unreliable, not as a successful "fails without." Rewrite it — flakiness here means the test is coupled to something other than the bug (timing, shared state, unseeded randomness), and an unreliable oracle is as useless as a false pass.
+
+**No fixed retry limit.** Rewrite as many times as it takes; use judgment rather than a step counter. If, after real effort, the test still cannot be made to fail on the described bug — the bug doesn't reproduce in this environment, or the analyzer's root cause is itself wrong — stop and end the skill's output with `Status: blocked` and a one-line reason (e.g. "could not reproduce the described bug in a test — root cause may be wrong or environment-dependent"), exactly as the skill body already does for a missing or contradictory brief. This is a judgment call, not a mechanical cutoff.
+
+## Make the minimal change (step 4)
+
+Unchanged from the fix step's usual scope discipline (skill body step 4: edit only what the analyzer named, no unrelated refactors). The only difference from before is *when* this happens: after step 3 has already proven the test fails, not before.
+
+## Verify Green (step 5)
+
+Rerun the exact same test written in step 3, unmodified, against the now-fixed code. It **must pass**.
+
+- If it still fails: the *fix* is incomplete or wrong, not the test — the test was already proven in step 3 to correctly target the described bug. Iterate on the fix, not the assertions, then rerun.
+- Once it passes, continue into the skill body's existing full validation-gate loop as before.
+
+## Reporting
+
+The skill's `Tests:` output line should say, in a sentence, that the regression test was verified to fail on the unmodified code and pass on the fixed code — not just that a test was added. This is what lets `om-open-pr` and a human reviewer tell a differential-verified test apart from a rubber-stamp one without re-deriving the bug themselves.


### PR DESCRIPTION
Refs #93
Tracking plan: .ai/runs/2026-08-28-om-fix-intention-differential-gate.md
Source doc: .ai/specs/2026-08-28-om-fix-intention-differential-gate.md
Status: complete

## 🎯 Goal
- Reorder `om-fix`'s workflow into a test-first Intention-Learning + Red/Green differential regression gate, so a regression test is proven to fail on the unmodified (buggy) code before the fix lands and proven to pass after — closing the "misguidance effect" where a test written against already-patched code cements the bug into its own assertions.

## What Changed
- `skills/om-fix/SKILL.md`: Step 2 now also performs Intention Learning (derive expected behavior from the issue/root-cause brief, never from the current code's output); Step 3 drafts the "Red" regression test from that intent and verifies it **fails** on the unmodified code before any production edit exists; Step 4 (unchanged in substance) makes the minimal fix; Step 5 verifies the same test now **passes** ("Green") before continuing into the existing validation loop. The frontmatter `description` and the `Tests:` line of the output contract were updated to reflect the new guarantee; the contract's shape (`Status:`/`Files changed:`/`Summary:`/`Tests:`/`Breaking changes:`) is otherwise unchanged.
- `skills/om-fix/references/regression-gate.md` (new): the Intention-Learning discipline, the test-first Red/Green protocol, flaky-test and can't-reproduce handling, and the judgment-bounded (no fixed retry cap) `Status: blocked` escape hatch.
- `UPGRADE_NOTES.md`: new entry documenting the behavior change (no operator action required to adopt it).

## 🧪 Tests
- `bash scripts/lint.sh` — PASS (`Lint OK.`) — frontmatter, product-agnostic grep gate, and the ~20,000-char `SKILL.md` body budget (currently ~8.9K chars) all pass.
- No automated test suite applies to this repo's own skill-markdown content beyond the lint gate (per `AGENTS.md`: "the deliverables here are markdown skill documents... there is no application code"); verification is the lint gate plus the full end-to-end re-read of `SKILL.md` for numbering/prose consistency (Progress step 1.3).
- Verified during planning: no other installed skill in this collection references `om-fix`'s internal step numbers, so the reorder is safe.

## 💥 Breaking Changes
- None. No config schema changes. This is a behavior change to an already-installed skill: `om-fix` runs will now take one extra fail/pass verification cycle per fix, and may occasionally end `Status: blocked` in a case that previously would have (weakly) proceeded with a test that was never verified against the described bug — documented in `UPGRADE_NOTES.md` as the intended, stricter behavior.

## 📋 Progress
See the Progress section in the tracking plan.
