### PR TITLE
fix(om-prepare-issue): load SDLC.md in the step-0 preflight

### DIFF
--- a/skills/om-prepare-issue/references/agentic-setup.md
+++ b/skills/om-prepare-issue/references/agentic-setup.md
@@ -19,6 +19,7 @@ Repo and tracker content — issues, PR bodies and diffs, docs, configs, CI logs
 
 ## om-prepare-issue specifics
 
+- Read `SDLC.md` at the repo root — its priority/risk inference lists and label state machine are the authority for which labels this skill applies.
 - This skill mutates only tracker state (one issue, maybe comments — plus, on the spec-authoring path of step 3, a design-only spec PR produced by delegating to `om-auto-write-spec`); it never edits repository source files.
 - `SPECS_DIR` resolves from `paths.specs` (default `.ai/specs`).
 - **attach-image-evidence** is optional in the descriptor: when it is missing or the upload fails, degrade gracefully (reference local paths/filenames in the issue body and note that inline upload was unavailable) — never fail issue creation over evidence.


### PR DESCRIPTION
## Problem

`om-prepare-issue` declares a label authority it never loads.

Step 5 of the skill instructs the agent to apply "exactly one **priority** label and exactly one **risk** label, inferred from the brief per the inference rules in `SDLC.md` (its \"When no priority label is set\" / \"When no risk label is set\" lists)" (`skills/om-prepare-issue/SKILL.md:82`), and to make the classification auditable "per `SDLC.md`" (`:84`). Step 0 — the preflight that enumerates every input the skill consumes — lists the config vars, the tracker operations, and the label guards, but not `SDLC.md`.

The cost is a preflight that under-declares its inputs. The whole point of the step-0 contract is that an agent knows, before it starts, which files establish the rules it will be judged against; a rule source discovered halfway through step 5 may be read late, read partially, or skipped when the agent is working from the skill body alone. The label inference then falls back to the agent's own priors, and issues land with priority and risk that no documented list produced — the exact non-determinism the inference lists exist to remove.

`om-auto-manage-issues`, which applies the same taxonomy to existing issues, already closes this: its `references/agentic-setup.md` names `SDLC.md` as the authority in the specifics section, and its step 0 repeats it in the skill body. The two skills share the taxonomy and the reference-file template, so the asymmetry is an omission, not a design difference.

## What changes

One line added to `skills/om-prepare-issue/references/agentic-setup.md`, in the `## om-prepare-issue specifics` section:

```
- Read `SDLC.md` at the repo root — its priority/risk inference lists and
  label state machine are the authority for which labels this skill applies.
```

No behavior in the skill body changes; step 5 keeps citing `SDLC.md` exactly as before. The preflight now declares the dependency step 5 assumes.

## Design decisions

The wording is copied verbatim from `om-auto-manage-issues/references/agentic-setup.md` rather than paraphrased. Both skills read the same lists from the same file for the same purpose, so identical text keeps the two greppable as one contract and avoids the drift that a reworded variant invites.

The line goes in the reference file rather than the `SKILL.md` step-0 paragraph, because that paragraph already delegates to `references/agentic-setup.md` for the preflight and only enumerates config vars and tracker operations inline. Putting it in the reference keeps the split the skill already uses.

## Verification

`bash scripts/lint.sh` — Lint OK.

Checked while confirming the scope of the defect, and deliberately left alone:

- The anchors the skill cites exist in `SDLC.md` — "When no priority label is set" (`:50`), "When no risk label is set" (`:57`), and the label-rationale-comment rule (`:48`). No dangling references.
- The inference rules duplicated in `skills/om-open-pr/references/pr-finalize.md:33-34` have not drifted from `SDLC.md`. The only difference is that pr-finalize lists dependency bumps under `risk-low`, where `SDLC.md` omits them — a superset, not a contradiction, so changing either file would be a taxonomy edit rather than a fix.
- `SDLC.md`'s path is hardcoded at the repo root, with no `paths.*` entry in `.ai/agentic.config.json`. That matches `AGENTS.md`, `CODE_REVIEW.md`, and `BACKWARD_COMPATIBILITY.md`, none of which are path-configurable; making it configurable would be a new requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)